### PR TITLE
fix(ux): réparer le signup (mdp 12+) et dégraisser l'écran Discover

### DIFF
--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -5,8 +5,24 @@ import { useState, FormEvent } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { signIn } from 'next-auth/react'
+import { registerUserSchema } from '@/features/auth/schemas'
 import StatusBanner from '@/shared/ui/StatusBanner'
 import SurfaceCard from '@/shared/ui/SurfaceCard'
+
+const PASSWORD_RULE = '12 caractères minimum, avec une majuscule, une minuscule et un chiffre.'
+
+function registerErrorMessage(code?: string) {
+  switch (code) {
+    case 'email_exists':
+      return 'Un compte existe déjà avec cet email. Connecte-toi plutôt.'
+    case 'rate_limited':
+      return 'Trop de tentatives. Réessaie dans une minute.'
+    case 'invalid_body':
+      return `Mot de passe trop faible : ${PASSWORD_RULE}`
+    default:
+      return 'Inscription impossible pour le moment. Réessaie.'
+  }
+}
 
 export default function SignUpPage() {
   const [email, setEmail] = useState('')
@@ -17,20 +33,32 @@ export default function SignUpPage() {
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault()
-    setLoading(true)
     setError(null)
+
+    // Validation client via le même schéma que l'API (source de vérité unique).
+    const parsed = registerUserSchema.safeParse({ email, password })
+    if (!parsed.success) {
+      const onPassword = parsed.error.issues.some((issue) => issue.path[0] === 'password')
+      setError(onPassword ? `Mot de passe : ${PASSWORD_RULE}` : 'Entre une adresse email valide.')
+      return
+    }
+
+    setLoading(true)
     const res = await fetch('/api/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify(parsed.data),
     })
+
     if (!res.ok) {
       setLoading(false)
-      setError((await res.json()).error || 'Inscription impossible')
+      const code = (await res.json().catch(() => ({}))).error as string | undefined
+      setError(registerErrorMessage(code))
       return
     }
-    // connexion auto
-    await signIn('credentials', { email, password, redirect: false })
+
+    // Connexion auto
+    await signIn('credentials', { email: parsed.data.email, password, redirect: false })
     router.replace('/')
   }
 
@@ -48,8 +76,11 @@ export default function SignUpPage() {
 
         <form onSubmit={onSubmit} className="space-y-5">
           <div className="space-y-2">
-            <label className="label">Email</label>
+            <label className="label" htmlFor="signup-email">
+              Email
+            </label>
             <input
+              id="signup-email"
               type="email"
               value={email}
               onChange={e => setEmail(e.target.value)}
@@ -59,16 +90,23 @@ export default function SignUpPage() {
             />
           </div>
           <div className="space-y-2">
-            <label className="label">Mot de passe (≥ 6 caractères)</label>
+            <label className="label" htmlFor="signup-password">
+              Mot de passe
+            </label>
             <input
+              id="signup-password"
               type="password"
               value={password}
               onChange={e => setPassword(e.target.value)}
               className="input"
               required
-              minLength={6}
+              minLength={12}
               autoComplete="new-password"
+              aria-describedby="signup-password-hint"
             />
+            <p id="signup-password-hint" className="field-hint">
+              {PASSWORD_RULE}
+            </p>
           </div>
           {error ? <StatusBanner tone="error">{error}</StatusBanner> : null}
           <button

--- a/app/src/app/discover/page.tsx
+++ b/app/src/app/discover/page.tsx
@@ -38,27 +38,17 @@ export default async function DiscoverPage({ searchParams }: DiscoverPageProps =
       <PageHeader
         eyebrow="Découverte"
         title="Découvertes"
-        description="Balaye à droite pour enregistrer un like, à gauche pour passer. Le clavier reste actif avec ← et → pour garder un rythme rapide."
-        meta={
-          <>
-            <span className="chip">{works.total} propositions disponibles</span>
-            <span className="chip">Deck mobile-first</span>
-          </>
-        }
+        description="Théâtre et cinéma à Paris, une carte à la fois."
+        meta={<span className="chip">{works.total} à découvrir</span>}
       >
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <SegmentedControl
-            ariaLabel="Sections culturelles"
-            value={section}
-            items={[
-              { label: 'Théâtre', value: 'theatre', href: '/discover?section=theatre' },
-              { label: 'Cinéma', value: 'cinema', href: '/discover?section=cinema' },
-            ]}
-          />
-          <p className="text-sm leading-6 text-muted-foreground">
-            Un seul objet à lire à la fois, avec les informations utiles directement sur la carte.
-          </p>
-        </div>
+        <SegmentedControl
+          ariaLabel="Sections culturelles"
+          value={section}
+          items={[
+            { label: 'Théâtre', value: 'theatre', href: '/discover?section=theatre' },
+            { label: 'Cinéma', value: 'cinema', href: '/discover?section=cinema' },
+          ]}
+        />
       </PageHeader>
 
       <SwipeDeck items={works.items} totalCount={works.total} />

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -65,7 +65,6 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
           <MetaStat label="Dates" value={dateLabel} />
           <MetaStat label="Budget" value={priceLabel} />
           {durationLabel ? <MetaStat label="Durée" value={durationLabel} /> : null}
-          {work.venue ? <MetaStat label="Lieu" value={work.venue} /> : null}
         </div>
 
         {work.sourceUrl ? (

--- a/app/src/features/works/ui/SwipeDeck.tsx
+++ b/app/src/features/works/ui/SwipeDeck.tsx
@@ -200,14 +200,8 @@ export default function SwipeDeck({ items, totalCount }: Props) {
       aria-label="Sélection de découvertes à balayer"
       className="mx-auto flex w-full max-w-5xl flex-col gap-4 select-none"
     >
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="page-meta">
-          <span className="chip">Carte {Math.min(index + 1, visibleTotal)} / {visibleTotal}</span>
-          <span className="chip">Glisse ou utilise les fleches</span>
-        </div>
-        <p className="text-sm leading-6 text-muted-foreground">
-          A droite pour enregistrer un coup de coeur, a gauche pour passer sans bruit.
-        </p>
+      <div className="page-meta">
+        <span className="chip">Carte {Math.min(index + 1, visibleTotal)} / {visibleTotal}</span>
       </div>
 
       <div className="relative flex min-h-[38rem] items-center justify-center pb-2">


### PR DESCRIPTION
#1 Signup (parcours d'inscription cassé):
- label/hint alignés sur la vraie politique (12 car., maj/min/chiffre)
- validation client via registerUserSchema (source de vérité unique) → feedback instantané
- codes d'erreur serveur mappés en messages lisibles (fini le brut "invalid_body")
- minLength 6 -> 12

#3 Discover (allègement de l'écran le plus vu):
- en-tête: description concise, 4 chips -> 1, suppression des 2 paragraphes d'instructions redondants -> la carte remonte au-dessus de la ligne de flottaison
- SwipeDeck: suppression du chip + paragraphe d'instructions redondants
- CardWork: suppression du lieu affiché en double (déjà sur l'image)