### PR TITLE
style(ui): alléger les design tokens (ombres, rayons, fond) — #6

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -18,10 +18,10 @@
   --color-danger-soft: #f9ece9;
   --color-success: #23644b;
   --color-success-soft: #e8f4ed;
-  --shadow-sm: 0 10px 30px rgba(54, 39, 24, 0.08);
-  --shadow-lg: 0 22px 55px rgba(54, 39, 24, 0.16);
-  --radius-panel: 1.75rem;
-  --radius-control: 1rem;
+  --shadow-sm: 0 2px 8px rgba(54, 39, 24, 0.06);
+  --shadow-lg: 0 8px 24px rgba(54, 39, 24, 0.09);
+  --radius-panel: 1rem;
+  --radius-control: 0.7rem;
 }
 
 * {
@@ -37,10 +37,7 @@ body {
   margin: 0;
   font-family: var(--font-manrope);
   color: var(--color-text);
-  background:
-    radial-gradient(circle at top left, rgba(15, 93, 94, 0.12), transparent 32%),
-    radial-gradient(circle at top right, rgba(174, 120, 83, 0.13), transparent 28%),
-    linear-gradient(180deg, var(--color-page-top) 0%, var(--color-page) 100%);
+  background: linear-gradient(180deg, var(--color-page-top) 0%, var(--color-page) 100%);
 }
 
 a {
@@ -146,7 +143,7 @@ a {
   gap: 0.35rem;
   padding: 1rem 1.1rem;
   border: 1px solid rgba(15, 93, 94, 0.12);
-  border-radius: 1.25rem;
+  border-radius: var(--radius-control);
   background: rgba(255, 255, 255, 0.72);
 }
 
@@ -268,7 +265,7 @@ a {
 
 .btn:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(54, 39, 24, 0.1);
+  box-shadow: 0 4px 12px rgba(54, 39, 24, 0.08);
 }
 
 .btn:disabled {
@@ -280,7 +277,7 @@ a {
   border-color: transparent;
   background: var(--color-accent);
   color: #fff;
-  box-shadow: 0 14px 30px rgba(15, 93, 94, 0.24);
+  box-shadow: 0 3px 10px rgba(15, 93, 94, 0.16);
 }
 
 .btn-primary:hover:not(:disabled) {
@@ -383,7 +380,7 @@ a {
 .segmented-control__item--active {
   background: var(--color-surface-strong);
   color: var(--color-text);
-  box-shadow: 0 10px 24px rgba(54, 39, 24, 0.08);
+  box-shadow: 0 2px 6px rgba(54, 39, 24, 0.08);
 }
 
 .segmented-control__item--full {
@@ -410,7 +407,7 @@ a {
   max-width: 100%;
   padding: 0.9rem 1rem;
   border: 1px solid var(--color-border);
-  border-radius: 1.15rem;
+  border-radius: var(--radius-control);
   box-shadow: var(--shadow-sm);
   font-size: 0.92rem;
   font-weight: 600;


### PR DESCRIPTION
Réduit la "lourdeur" visuelle globale (globals.css uniquement) :
- ombres : --shadow-sm 0 10px 30px -> 0 2px 8px ; --shadow-lg 0 22px 55px -> 0 8px 24px
- rayons : --radius-panel 1.75rem -> 1rem ; --radius-control 1rem -> 0.7rem
- fond : suppression des 2 dégradés radial colorés (glows) -> fond plat et calme
- ombres codées en dur allégées (btn-primary, btn:hover, segmented actif)
- status-banner & auth-highlight-card alignés sur --radius-control

Touche tous les écrans (vérifié visuellement sur /signup). Suite possible : aligner les rayons inline des composants (SwipeDeck/CardWork) sur la nouvelle échelle.