### PR TITLE
fix(ci): prisma generate sans DATABASE_URL + couverture sans dossier …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ scraper/__pycache__/
 scraper/logs/
 data/*.tmp
 *.tsbuildinfo
+coverage/
 *.py[cod]
 
 # Gros artefacts locaux (sauvegardes / dumps) — ne jamais committer

--- a/app/prisma.config.ts
+++ b/app/prisma.config.ts
@@ -1,9 +1,17 @@
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
+
+// On lit `process.env.DATABASE_URL` directement (et non `env()` de prisma/config,
+// qui throw immédiatement si la variable manque). Ainsi `prisma generate` — qui
+// n'a pas besoin d'une vraie URL — fonctionne sans DATABASE_URL (CI, clone neuf
+// sans .env). Les commandes DB réelles (migrate deploy) reçoivent la vraie URL
+// via l'environnement ; le placeholder ne sert que de repli inoffensif.
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://placeholder:placeholder@localhost:5432/placeholder";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
   datasource: {
-    url: env("DATABASE_URL"),
+    url: DATABASE_URL,
   },
 });

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
     css: true, // autorise l'import de css/clsx/tw si besoin
     coverage: {
       provider: 'v8',
+      // `text` uniquement : pas de rapport HTML (dossier coverage/) → évite que
+      // ESLint analyse des assets générés, et accélère la CI. Les seuils restent enforced.
+      reporter: ['text'],
       include: ['src/**'],
       exclude: ['src/generated/**', '**/*.d.ts', '**/.DS_Store'],
       // Plancher anti-régression (ratchet) — relever au fil des tests ajoutés.


### PR DESCRIPTION
…HTML

La CI échouait à `pnpm install --frozen-lockfile` : le postinstall `prisma generate` charge prisma.config.ts qui appelait `env("DATABASE_URL")` — évalué immédiatement, il throw quand la variable manque (CI sans secret, ou clone neuf sans .env). Or `prisma generate` n'a pas besoin de l'URL.

- prisma.config.ts : `process.env.DATABASE_URL ?? <placeholder>` au lieu de `env()` (plus de throw au chargement ; les commandes DB réelles reçoivent la vraie URL).
- vitest : reporter de couverture `text` seul → plus de dossier coverage/ généré (évitait un faux échec de lint sur des assets istanbul) ; seuils toujours enforced.
- .gitignore : coverage/.