### PR TITLE
feat: casting + réalisateur sur la carte Discover (récupération PR #23 orpheline)

### DIFF
--- a/app/prisma/migrations/20260607130000_add_work_cast/migration.sql
+++ b/app/prisma/migrations/20260607130000_add_work_cast/migration.sql
@@ -1,0 +1,3 @@
+-- Casting + réalisateur/metteur en scène sur les œuvres (additif, non destructif).
+ALTER TABLE "Work" ADD COLUMN "director" TEXT;
+ALTER TABLE "Work" ADD COLUMN "cast" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -83,6 +83,8 @@ model Work {
   priceMin  Float?
   priceMax  Float?
   imageUrl  String?
+  director  String?
+  cast      String[]
   sourceUrl String    @unique
 
   // ✅ Réactions (remplace l'ancien Work.likes)

--- a/app/scripts/backfill-credits.ts
+++ b/app/scripts/backfill-credits.ts
@@ -1,0 +1,69 @@
+// Backfill one-off : remplit Work.director / Work.cast pour les œuvres existantes
+// (les nouveaux scrapes les capturent désormais nativement). Récupère la fiche
+// Offi, délègue l'extraction à scraper/extract_credits_cli.py (même logique que le
+// scraper, zéro duplication), puis met à jour via Prisma.
+//
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/backfill-credits.ts [limit]
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { prisma } from '@/server/db'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const scraperDir = path.resolve(here, '../../scraper')
+const PY = path.join(scraperDir, '.venv/bin/python')
+const CLI = path.join(scraperDir, 'extract_credits_cli.py')
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+
+const limit = Number(process.argv[2] ?? 40)
+
+function extract(html: string): { director: string | null; cast: string[] } {
+  const res = spawnSync(PY, [CLI], {
+    input: html,
+    encoding: 'utf-8',
+    cwd: scraperDir,
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 10_000,
+    killSignal: 'SIGKILL',
+  })
+  if (res.status !== 0 || !res.stdout) return { director: null, cast: [] }
+  try {
+    return JSON.parse(res.stdout)
+  } catch {
+    return { director: null, cast: [] }
+  }
+}
+
+async function main() {
+  const works = await prisma.work.findMany({
+    where: { cast: { isEmpty: true } },
+    select: { id: true, sourceUrl: true },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  let updated = 0
+  for (const work of works) {
+    try {
+      const response = await fetch(work.sourceUrl, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(15_000) })
+      if (!response.ok) continue
+      const { director, cast } = extract(await response.text())
+      if (director || cast.length > 0) {
+        await prisma.work.update({ where: { id: work.id }, data: { director, cast } })
+        updated += 1
+      }
+      await new Promise((resolve) => setTimeout(resolve, 400)) // throttle poli envers offi.fr
+    } catch {
+      // on saute les fiches en erreur, sans interrompre le backfill
+    }
+  }
+
+  console.log(JSON.stringify({ scanned: works.length, updated }))
+}
+
+main()
+  .catch((error) => {
+    console.error('[backfill-credits]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/app/src/features/offi-import/mappers.ts
+++ b/app/src/features/offi-import/mappers.ts
@@ -22,6 +22,8 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
     priceMin: record.price_min_eur ?? null,
     priceMax: record.price_max_eur ?? null,
     imageUrl: record.image ?? null,
+    director: record.director ?? null,
+    cast: record.cast ?? [],
     sourceUrl: record.url,
   }
 
@@ -40,6 +42,8 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
   if (record.price_min_eur != null) update.priceMin = record.price_min_eur
   if (record.price_max_eur != null) update.priceMax = record.price_max_eur
   if (record.image != null) update.imageUrl = record.image
+  if (record.director != null) update.director = record.director
+  if (record.cast.length > 0) update.cast = record.cast
 
   return { create, update }
 }

--- a/app/src/features/offi-import/schemas.ts
+++ b/app/src/features/offi-import/schemas.ts
@@ -69,6 +69,11 @@ export const offiWorkSchema = z
     price_max_eur: nullableMoney,
     image: nullableHttpUrl(500),
     description: nullableString(20_000),
+    director: nullableString(160),
+    cast: z.preprocess(
+      (value) => (Array.isArray(value) ? value : []),
+      z.array(z.string().trim().min(1).max(160)).max(20),
+    ),
     crawled_at: nullableDateTime,
   })
   .transform((record) => {

--- a/app/src/features/works/dto.ts
+++ b/app/src/features/works/dto.ts
@@ -15,6 +15,8 @@ export const workCardSelect = {
   durationMin: true,
   priceMin: true,
   priceMax: true,
+  director: true,
+  cast: true,
   sourceUrl: true,
 } satisfies Prisma.WorkSelect
 
@@ -34,6 +36,8 @@ export type WorkCardDto = {
   durationMin: number | null
   priceMin: number | null
   priceMax: number | null
+  director: string | null
+  cast: string[]
   sourceUrl: string | null
 }
 
@@ -52,6 +56,8 @@ export function mapWorkToCardDto(work: WorkCardRecord): WorkCardDto {
     durationMin: work.durationMin,
     priceMin: work.priceMin,
     priceMax: work.priceMax,
+    director: work.director,
+    cast: work.cast,
     sourceUrl: work.sourceUrl,
   }
 }

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -27,6 +27,7 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
   const description = work.description?.trim()
   const genres = parseGenres(work.category)
   const sectionLabel = work.section === 'cinema' ? 'Cinéma' : 'Théâtre'
+  const directorLabel = work.section === 'cinema' ? 'De' : 'Mise en scène'
   const hasFacts = genres.length > 0 || Boolean(durationLabel) || Boolean(priceLabel)
 
   return (
@@ -70,6 +71,23 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
             {work.title}
           </h2>
         </div>
+
+        {work.director || work.cast.length > 0 ? (
+          <div className="space-y-0.5 text-sm leading-6">
+            {work.director ? (
+              <p>
+                <span className="text-[color:var(--color-text-muted)]">{directorLabel} </span>
+                <span className="font-semibold text-[color:var(--color-text)]">{work.director}</span>
+              </p>
+            ) : null}
+            {work.cast.length > 0 ? (
+              <p>
+                <span className="text-[color:var(--color-text-muted)]">Avec </span>
+                <span className="font-medium text-[color:var(--color-text)]">{work.cast.slice(0, 5).join(', ')}</span>
+              </p>
+            ) : null}
+          </div>
+        ) : null}
 
         {hasFacts ? (
           <div className="flex flex-wrap items-center gap-2">

--- a/app/tests/card-work.test.tsx
+++ b/app/tests/card-work.test.tsx
@@ -23,6 +23,8 @@ const base: WorkCardDto = {
   durationMin: 80,
   priceMin: null,
   priceMax: null,
+  director: 'Kelly Reichardt',
+  cast: ['Michelle Williams', 'Will Oldham'],
   sourceUrl: 'https://www.offi.fr/x',
 }
 
@@ -40,6 +42,12 @@ describe('CardWork', () => {
     // la date est retirée
     expect(screen.queryByText(/2009/)).not.toBeInTheDocument()
     expect(screen.queryByText(/avr\./)).not.toBeInTheDocument()
+  })
+
+  it('affiche le réalisateur et le casting (signal de décision)', () => {
+    render(<CardWork work={base} />)
+    expect(screen.getByText(/Kelly Reichardt/)).toBeInTheDocument()
+    expect(screen.getByText(/Michelle Williams/)).toBeInTheDocument()
   })
 
   it('« Voir plus » déplie la description complète', async () => {

--- a/app/tests/like.test.tsx
+++ b/app/tests/like.test.tsx
@@ -5,8 +5,8 @@ import SwipeDeck from '@/features/works/ui/SwipeDeck'
 
 test("avance à la carte suivante et appelle POST /api/reactions quand on clique Like", async () => {
   const items = [
-    { id: 'w1', title: 'Œuvre 1', section: 'theatre', imageUrl: null, category: null, venue: null, address: null, description: null, startDate: null, endDate: null, durationMin: null, priceMin: null, priceMax: null, sourceUrl: null },
-    { id: 'w2', title: 'Œuvre 2', section: 'theatre', imageUrl: null, category: null, venue: null, address: null, description: null, startDate: null, endDate: null, durationMin: null, priceMin: null, priceMax: null, sourceUrl: null },
+    { id: 'w1', title: 'Œuvre 1', section: 'theatre', imageUrl: null, category: null, venue: null, address: null, description: null, startDate: null, endDate: null, durationMin: null, priceMin: null, priceMax: null, director: null, cast: [], sourceUrl: null },
+    { id: 'w2', title: 'Œuvre 2', section: 'theatre', imageUrl: null, category: null, venue: null, address: null, description: null, startDate: null, endDate: null, durationMin: null, priceMin: null, priceMax: null, director: null, cast: [], sourceUrl: null },
   ]
 
   render(<SwipeDeck items={items} />)

--- a/app/tests/swipe-undo.test.tsx
+++ b/app/tests/swipe-undo.test.tsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event'
 import SwipeDeck from '@/features/works/ui/SwipeDeck'
 
 const items = [
-  { id: 'w1', title: 'Œuvre 1', section: 'theatre', imageUrl: null, category: null, venue: null, address: null, description: null, startDate: null, endDate: null, durationMin: null, priceMin: null, priceMax: null, sourceUrl: null },
-  { id: 'w2', title: 'Œuvre 2', section: 'theatre', imageUrl: null, category: null, venue: null, address: null, description: null, startDate: null, endDate: null, durationMin: null, priceMin: null, priceMax: null, sourceUrl: null },
+  { id: 'w1', title: 'Œuvre 1', section: 'theatre', imageUrl: null, category: null, venue: null, address: null, description: null, startDate: null, endDate: null, durationMin: null, priceMin: null, priceMax: null, director: null, cast: [], sourceUrl: null },
+  { id: 'w2', title: 'Œuvre 2', section: 'theatre', imageUrl: null, category: null, venue: null, address: null, description: null, startDate: null, endDate: null, durationMin: null, priceMin: null, priceMax: null, director: null, cast: [], sourceUrl: null },
 ]
 
 test('annule le dernier swipe : revient à la carte précédente et DELETE /api/reactions', async () => {

--- a/scraper/extract_credits_cli.py
+++ b/scraper/extract_credits_cli.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Lit le HTML d'une fiche Offi sur stdin, imprime {"director","cast"} en JSON.
+Réutilise parsers.extract_credits (même logique que le scraper) — utilisé par le
+backfill one-off app/scripts/backfill-credits.ts."""
+import sys
+import json
+
+from bs4 import BeautifulSoup
+
+try:
+    from scraper import parsers  # contexte package
+except ImportError:  # exécuté depuis le dossier scraper/
+    import parsers  # type: ignore[no-redef]
+
+
+def main() -> None:
+    html = sys.stdin.read()
+    director, cast = parsers.extract_credits(BeautifulSoup(html, "html.parser"))
+    print(json.dumps({"director": director, "cast": cast}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/offi_scraper.py
+++ b/scraper/offi_scraper.py
@@ -17,7 +17,7 @@ import random
 import re
 import sys
 import time
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple, List
 from urllib.parse import urljoin, urlparse, urlunparse, urlencode, parse_qsl
@@ -170,6 +170,8 @@ class Show:
     price_max_eur: Optional[float] = None
     image: Optional[str] = None
     description: Optional[str] = None
+    director: Optional[str] = None
+    cast: list[str] = field(default_factory=list)
     crawled_at: Optional[str] = None
 
     def is_empty(self) -> bool:
@@ -369,6 +371,8 @@ class OffiScraper:
             price_max_eur=payload.get("price_max_eur"),
             image=payload.get("image"),
             description=payload.get("description"),
+            director=payload.get("director"),
+            cast=payload.get("cast") or [],
             crawled_at=payload.get("crawled_at"),
         )
 
@@ -925,6 +929,12 @@ class OffiScraper:
 
         if not show.description:
             show.description = self._extract_description(soup)
+
+        director, cast = parsers.extract_credits(soup)
+        if not show.director:
+            show.director = director
+        if not show.cast and cast:
+            show.cast = cast
 
         if show.section == "cinema":
             return self._complete_cinema_show_from_detail_page(show, soup)

--- a/scraper/parsers.py
+++ b/scraper/parsers.py
@@ -76,3 +76,81 @@ def parse_prices(text: str) -> tuple[Optional[float], Optional[float]]:
     if len(prices) == 1:
         return prices[0], prices[0]
     return min(prices), max(prices)
+
+
+# --- Casting / mise en scène ---------------------------------------------------
+# Offi expose les crédits différemment selon le segment :
+#  - cinéma : bloc "fiche technique" labellisé ("Réalisation : X", "Principaux artistes : A, B")
+#    + des liens itemprop="actors" (acteurs "(personnage)" mêlés à l'équipe "(scénario)"…) ;
+#  - théâtre : une phrase de crédit ("De A, B, mise en scène C[, avec D, E]") avec itemprop="performer".
+# On scope l'extraction à ces blocs pour éviter le bruit (footer "Avec L'Officiel des spectacles !").
+
+# Rôles d'équipe à exclure du casting (parenthèse sur les liens acteurs cinéma).
+_CREW_ROLES = {
+    "scénario", "scenario", "musique", "montage", "image", "photographie", "photo",
+    "son", "décors", "decors", "costumes", "production", "dialogues", "adaptation",
+    "réalisation", "realisation", "d'après", "auteur", "mixage", "effets",
+}
+_CREDIT_STOP = (
+    r"(?:Principaux|Genre|Nationalit|Dur[ée]e|Ann[ée]e|Date|Distributeur|Num[ée]ro|Sc[ée]nario|Visa|\||$)"
+)
+
+
+def _clean_credit(value: str) -> str:
+    return re.sub(r"\s+", " ", value or "").strip(" ,.;:•|")
+
+
+def _name_only(text: str) -> str:
+    # "Alida Valli ( Louise )" -> "Alida Valli"
+    return _clean_credit(re.sub(r"\(.*$", "", text or ""))
+
+
+def _tech_block_text(soup) -> str:
+    label = soup.find(string=re.compile(r"R[ée]alisation\s*:", re.IGNORECASE))
+    if not label:
+        return ""
+    node = label.parent
+    for _ in range(4):
+        if node is None or len(node.get_text(" ", strip=True)) > 60:
+            break
+        node = node.parent
+    return _clean_credit(node.get_text(" ", strip=True)) if node else ""
+
+
+def extract_credits(soup) -> tuple[Optional[str], list[str]]:
+    """Retourne (director, cast) depuis une fiche Offi (BeautifulSoup). Robuste théâtre + cinéma."""
+    perf_links = soup.select('a[itemprop="performer"], a[itemprop="actors"]')
+    perf_block = _clean_credit(perf_links[0].parent.get_text(" ", strip=True)) if perf_links else ""
+    tech_block = _tech_block_text(soup)
+
+    director: Optional[str] = None
+    tech_match = re.search(r"R[ée]alisation\s*:?\s*(.+?)\s+" + _CREDIT_STOP, tech_block, re.IGNORECASE)
+    if tech_match and _clean_credit(tech_match.group(1)):
+        director = _clean_credit(tech_match.group(1))
+    if not director:
+        stage_match = re.search(r"mise en sc[èe]ne\s+([A-ZÉÈÀ][^,.|]{2,60})", perf_block, re.IGNORECASE)
+        if stage_match:
+            director = _clean_credit(stage_match.group(1))
+
+    cast: list[str] = []
+    main = re.search(r"Principaux artistes\s*:?\s*(.+?)\s+" + _CREDIT_STOP, tech_block, re.IGNORECASE)
+    if main:
+        cast = [_clean_credit(c) for c in re.split(r",| et ", main.group(1)) if _clean_credit(c)]
+    if not cast:
+        avec = re.search(r"\bavec\s+(.+?)(?:[.;]|$)", perf_block, re.IGNORECASE)
+        if avec:
+            cast = [_clean_credit(c) for c in re.split(r",| et ", avec.group(1)) if _clean_credit(c)]
+    if not cast:
+        seen: set[str] = set()
+        for link in soup.select('a[itemprop="actors"]'):
+            text = link.get_text(" ", strip=True)
+            role = re.search(r"\(([^)]+)\)", text)
+            if role and role.group(1).strip().lower() in _CREW_ROLES:
+                continue
+            name = _name_only(text)
+            if name and name.lower() not in seen:
+                seen.add(name.lower())
+                cast.append(name)
+
+    cast = [c for c in cast if c and c != director and 2 <= len(c) <= 40][:8]
+    return director, cast

--- a/scraper/tests/test_parsers.py
+++ b/scraper/tests/test_parsers.py
@@ -1,6 +1,56 @@
 import unittest
 
+from bs4 import BeautifulSoup
+
 from scraper import parsers
+
+
+def _soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, "html.parser")
+
+
+class ExtractCreditsTests(unittest.TestCase):
+    def test_cinema_labelled_block(self):
+        html = """
+        <div class="fiche">Réalisation : <a href="/artiste/x">Georges Franju</a>
+          Principaux artistes : <a href="/artiste/a">Pierre Brasseur</a>, <a href="/artiste/b">Alida Valli</a>
+          Genre : Horreur</div>
+        <footer>Avec L'Officiel des spectacles !</footer>
+        """
+        director, cast = parsers.extract_credits(_soup(html))
+        self.assertEqual(director, "Georges Franju")
+        self.assertEqual(cast, ["Pierre Brasseur", "Alida Valli"])
+
+    def test_cinema_itemprop_fallback_excludes_crew(self):
+        html = """
+        <div>Réalisation : <a href="/artiste/x">Jane Doe</a> Genre : Drame</div>
+        <div><a itemprop="actors" href="/a">Actor One ( Hero )</a>
+             <a itemprop="actors" href="/b">Composer Guy (musique)</a></div>
+        """
+        director, cast = parsers.extract_credits(_soup(html))
+        self.assertEqual(director, "Jane Doe")
+        self.assertEqual(cast, ["Actor One"])  # le membre d'équipe (musique) est exclu
+
+    def test_theatre_director_only(self):
+        html = (
+            '<p>De <a itemprop="performer" href="/x">Guilhem Connac</a>, '
+            '<a itemprop="performer" href="/y">Benoît Labannierre</a>, '
+            'mise en scène <a itemprop="performer" href="/z">Romain Thunin</a>.</p>'
+        )
+        director, cast = parsers.extract_credits(_soup(html))
+        self.assertEqual(director, "Romain Thunin")
+        self.assertEqual(cast, [])  # pas d'acteurs listés (auteurs non confondus avec le casting)
+
+    def test_theatre_with_avec_cast(self):
+        html = (
+            '<p>De <a itemprop="performer" href="/x">Dostoïevski</a>, '
+            'mise en scène <a itemprop="performer" href="/d">Dominique Scheer</a>, '
+            'avec <a itemprop="performer" href="/a">Jérémy Petit</a>, '
+            '<a itemprop="performer" href="/b">Milena Marinelli</a>.</p>'
+        )
+        director, cast = parsers.extract_credits(_soup(html))
+        self.assertEqual(director, "Dominique Scheer")
+        self.assertEqual(cast, ["Jérémy Petit", "Milena Marinelli"])
 
 
 class ParsersTests(unittest.TestCase):


### PR DESCRIPTION
## Contexte
La PR #23 (casting/réalisateur) ciblait `codex/swipe-undo` et a été mergée ~8 s **après** que #22 (`swipe-undo` → `main`) ait été fusionnée. Le commit `f6f1632` n'a donc jamais atteint `main`. Cette PR le récupère directement vers `main`.

## Contenu
- Migration additive `add_work_cast` (déjà appliquée sur Neon), schema `Work.director`/`Work.cast`, DTO.
- Affichage « De {réalisateur} / Avec {casting} » dans `CardWork`.
- Scraper : `parsers.extract_credits()` + CLI, intégration `offi_scraper`, mappers/schemas import.
- `scripts/backfill-credits.ts` (throttle 400 ms, hang-proof).
- Tests (card-work, parsers, like, swipe-undo).

Merge propre dans `main` (aucun conflit), CI verte sur `f6f1632`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)