### PR TITLE
feat(ux): casting + réalisateur sur la carte /likes (#2)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "offi-app",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "cd /Users/paulpignal/Desktop/offi-app/app && exec pnpm dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -19,6 +19,9 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
   const priceLabel = work ? formatPriceRange(work.priceMin, work.priceMax) : null
   const durationLabel = work ? formatDuration(work.durationMin) : null
   const description = work?.description?.trim()
+  const director = work?.director?.trim()
+  const castNames = work?.cast?.slice(0, 5) ?? []
+  const directorLabel = work?.section === 'cinema' ? 'De' : 'Mise en scène'
 
   return (
     <SurfaceCard className={cn('flex h-full flex-col overflow-hidden p-0', className)} tone="muted">
@@ -52,6 +55,22 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
         <div className="space-y-2">
           <h3 className="line-clamp-2 text-lg font-semibold tracking-[-0.03em] text-[color:var(--color-text)]">{title}</h3>
           {work?.venue ? <p className="text-sm font-medium text-muted-foreground">{work.venue}</p> : null}
+          {director || castNames.length > 0 ? (
+            <div className="space-y-0.5 text-sm leading-6">
+              {director ? (
+                <p>
+                  <span className="text-muted-foreground">{directorLabel} </span>
+                  <span className="font-semibold text-[color:var(--color-text)]">{director}</span>
+                </p>
+              ) : null}
+              {castNames.length > 0 ? (
+                <p>
+                  <span className="text-muted-foreground">Avec </span>
+                  <span className="font-medium text-[color:var(--color-text)]">{castNames.join(', ')}</span>
+                </p>
+              ) : null}
+            </div>
+          ) : null}
           {description ? <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">{description}</p> : null}
         </div>
 

--- a/app/tests/likes-library.test.tsx
+++ b/app/tests/likes-library.test.tsx
@@ -8,13 +8,17 @@ vi.mock('next/image', () => ({
 
 import LikesLibrary, { type LikedItem } from '@/features/reactions/ui/LikesLibrary'
 
-function makeItem(id: string, title: string): LikedItem {
+function makeItem(
+  id: string,
+  title: string,
+  credits?: { director?: string | null; cast?: string[]; section?: 'theatre' | 'cinema' },
+): LikedItem {
   return {
     workId: id,
     work: {
       id,
       title,
-      section: 'theatre',
+      section: credits?.section ?? 'theatre',
       imageUrl: null,
       category: null,
       venue: null,
@@ -25,6 +29,8 @@ function makeItem(id: string, title: string): LikedItem {
       durationMin: null,
       priceMin: null,
       priceMax: null,
+      director: credits?.director ?? null,
+      cast: credits?.cast ?? [],
       sourceUrl: null,
     },
   }
@@ -94,6 +100,20 @@ describe('LikesLibrary', () => {
       '/api/reactions',
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ workId: 'w1', status: 'LIKE' }) }),
     )
+  })
+
+  it('affiche le réalisateur et le casting sur la carte', () => {
+    render(
+      <LikesLibrary
+        current={[makeItem('w1', 'Voyage au bout de l’enfer', { section: 'cinema', director: 'Michael Cimino', cast: ['Robert De Niro', 'Christopher Walken'] })]}
+        archived={[]}
+        view="all"
+      />,
+    )
+
+    expect(screen.getByText('Michael Cimino')).toBeInTheDocument()
+    expect(screen.getByText('Robert De Niro, Christopher Walken')).toBeInTheDocument()
+    expect(screen.getByText(/^De$/)).toBeInTheDocument()
   })
 
   it('rollback : si le POST échoue, la carte revient avec un message d’erreur', async () => {


### PR DESCRIPTION
Affiche le réalisateur et le casting sur les cartes de la page /likes (`WorkSummaryCard`), comme sur Discover (`CardWork`). DTO + requête `listLikedWorks` exposaient déjà `director`/`cast` — seul laffichage manquait.

Test ajouté (rendu réal + casting), lint/typecheck/vitest verts en local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)