### PR TITLE
fix(ux): typo nav, déconnexion discrète, pages d erreur stylées

### DIFF
--- a/app/src/app/discover/error.tsx
+++ b/app/src/app/discover/error.tsx
@@ -9,7 +9,12 @@ export default function DiscoverError({
         <span className="chip">Découverte interrompue</span>
         <div className="space-y-2">
           <h1 className="text-2xl font-semibold tracking-[-0.03em]">Impossible de charger le deck</h1>
-          <p className="text-sm leading-7 text-[color:var(--color-danger)]">{error?.message ?? "Erreur inconnue"}</p>
+          <p className="text-sm leading-7 text-[color:var(--color-text-muted)]">
+            Le chargement des œuvres a échoué. Réessaie dans un instant.
+          </p>
+          {error?.digest ? (
+            <p className="text-xs text-[color:var(--color-text-muted)]">Référence&nbsp;: {error.digest}</p>
+          ) : null}
         </div>
       </div>
       <button

--- a/app/src/app/error.tsx
+++ b/app/src/app/error.tsx
@@ -1,17 +1,31 @@
-"use client";
-export default function GlobalError({
+'use client'
+
+export default function AppError({
   error,
   reset,
-}: { error: Error & { digest?: string }, reset: () => void }) {
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
   return (
-    <html>
-      <body style={{padding:20,fontFamily:"ui-sans-serif,system-ui"}}>
-        <h1 style={{fontSize:20,fontWeight:600}}>Une erreur est survenue</h1>
-        <p style={{marginTop:8,color:"#555"}}>{error?.message ?? "Erreur inconnue"}</p>
-        <button onClick={() => reset()} style={{marginTop:12,padding:"8px 12px",border:"1px solid #ddd",borderRadius:8}}>
-          Réessayer
-        </button>
-      </body>
-    </html>
-  );
+    <div className="page-shell">
+      <div className="mx-auto max-w-2xl">
+        <div className="surface-card space-y-4">
+          <span className="chip">Une erreur est survenue</span>
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold tracking-[-0.03em]">Quelque chose s’est mal passé</h1>
+            <p className="text-sm leading-7 text-[color:var(--color-text-muted)]">
+              Désolé, cette page n’a pas pu s’afficher. Tu peux réessayer ; si le problème persiste, reviens un peu plus tard.
+            </p>
+            {error?.digest ? (
+              <p className="text-xs text-[color:var(--color-text-muted)]">Référence&nbsp;: {error.digest}</p>
+            ) : null}
+          </div>
+          <button onClick={() => reset()} className="btn btn-primary">
+            Réessayer
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/app/src/app/global-error.tsx
+++ b/app/src/app/global-error.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+// Filet de sécurité de dernier recours : ne se déclenche que si le layout racine
+// lui-même échoue. Il remplace tout le document, donc les styles globaux ne sont
+// pas chargés → styles inline volontaires, et palette alignée sur la marque.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <html lang="fr">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 24,
+          fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+          background: '#faf6f0',
+          color: '#2a1e12',
+        }}
+      >
+        <div
+          style={{
+            maxWidth: 480,
+            width: '100%',
+            background: '#fff',
+            border: '1px solid rgba(42,30,18,0.08)',
+            borderRadius: 20,
+            padding: 28,
+            boxShadow: '0 18px 40px rgba(42,30,18,0.08)',
+          }}
+        >
+          <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 8px' }}>Quelque chose s’est mal passé</h1>
+          <p style={{ margin: '0 0 16px', fontSize: 14, lineHeight: 1.6, color: '#6b5d4d' }}>
+            Désolé, l’application n’a pas pu se charger. Réessaie ; si le problème persiste, reviens un peu plus tard.
+          </p>
+          {error?.digest ? (
+            <p style={{ margin: '0 0 16px', fontSize: 12, color: '#9a8c7a' }}>Référence : {error.digest}</p>
+          ) : null}
+          <button
+            onClick={() => reset()}
+            style={{
+              padding: '10px 16px',
+              border: 'none',
+              borderRadius: 12,
+              background: '#0f5d5e',
+              color: '#fff',
+              fontSize: 14,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Réessayer
+          </button>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/app/src/app/not-found.tsx
+++ b/app/src/app/not-found.tsx
@@ -1,9 +1,22 @@
+import Link from 'next/link'
+
 export default function NotFound() {
   return (
-    <div style={{padding:20}}>
-      <h1 style={{fontSize:20,fontWeight:600}}>404</h1>
-      <p>Cette page n’existe pas.</p>
-      <a href="/discover" style={{textDecoration:"underline"}}>Retour à Découverte</a>
+    <div className="page-shell">
+      <div className="mx-auto max-w-2xl">
+        <div className="surface-card space-y-4">
+          <span className="chip">Page introuvable</span>
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold tracking-[-0.03em]">404 — cette page n’existe pas</h1>
+            <p className="text-sm leading-7 text-[color:var(--color-text-muted)]">
+              Le lien est peut-être périmé ou la page a été déplacée.
+            </p>
+          </div>
+          <Link href="/discover" className="btn btn-primary">
+            Retour à Découverte
+          </Link>
+        </div>
+      </div>
     </div>
-  );
+  )
 }

--- a/app/src/features/auth/ui/LogoutButton.tsx
+++ b/app/src/features/auth/ui/LogoutButton.tsx
@@ -7,7 +7,7 @@ export default function LogoutButton() {
   return (
     <button
       onClick={() => signOut({ callbackUrl: SIGN_IN_PATH })}
-      className="btn btn-danger"
+      className="btn btn-ghost px-3 py-1.5 text-xs"
     >
       Se déconnecter
     </button>

--- a/app/src/features/auth/ui/NavBar.tsx
+++ b/app/src/features/auth/ui/NavBar.tsx
@@ -65,7 +65,7 @@ export default function NavBar() {
 
       <div className="flex flex-1 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div className="flex flex-wrap items-center gap-2">
-          <NavLink href="/discover">Decouverte</NavLink>
+          <NavLink href="/discover">Découverte</NavLink>
           <NavLink href="/likes">Mes likes</NavLink>
           <NavLink href="/friends">Amis</NavLink>
         </div>


### PR DESCRIPTION
Audit UX — lot de polish :

- **Nav** : « Decouverte » → « Découverte » (accent manquant).
- **Déconnexion** : `btn-danger` (rouge dominant) → `btn-ghost` discret, plus cohérent dans la nav.
- **Pages d erreur** : `error.tsx` restylée au design system (`surface-card`/`chip`/`btn`), **plus de fuite de `error.message`** (message générique + référence `digest`). Ajout de `global-error.tsx` (filet de sécurité si le layout racine échoue, stylé inline car hors CSS global). `not-found.tsx` restylée. `discover/error.tsx` : suppression de la fuite de `error.message` également.

lint/typecheck verts, 61/61 tests verts en local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)