### PR TITLE
feat(data): nettoyage de category à l ingestion (dédup des genres)

### DIFF
--- a/app/src/features/offi-import/mappers.ts
+++ b/app/src/features/offi-import/mappers.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from '@/generated/prisma/client'
 import type { OffiWorkRecord } from '@/features/offi-import/schemas'
+import { cleanCategory } from '@/features/works/category'
 
 function toDate(value: string | null) {
   return value ? new Date(`${value}T00:00:00.000Z`) : null
@@ -12,7 +13,7 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
   const create: Prisma.WorkCreateInput = {
     title: record.title,
     section: record.section,
-    category: record.category ?? null,
+    category: cleanCategory(record.category),
     venue: record.venue ?? null,
     address: record.address ?? null,
     description: record.description ?? null,
@@ -32,7 +33,7 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
     section: record.section,
   }
 
-  if (record.category != null) update.category = record.category
+  if (record.category != null) update.category = cleanCategory(record.category)
   if (record.venue != null) update.venue = record.venue
   if (record.address != null) update.address = record.address
   if (record.description != null) update.description = record.description

--- a/app/src/features/works/category.ts
+++ b/app/src/features/works/category.ts
@@ -1,0 +1,30 @@
+// La catégorie brute renvoyée par Offi est souvent dupliquée/concaténée
+// ("drame - drame / road-movie"). On découpe sur " / ", " · " et " - " (avec
+// espaces autour, pour préserver les genres composés type "road-movie"), on
+// nettoie et on dédoublonne (insensible à la casse, en gardant la 1re graphie).
+//
+// Partagé entre l'ingestion (offi-import → données propres en base) et
+// l'affichage (CardWork → chips), pour une logique unique.
+
+export function splitGenres(category: string | null | undefined): string[] {
+  if (!category) return []
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const part of category.split(/\s*[/·]\s*|\s+-\s+/)) {
+    const genre = part.trim()
+    if (!genre) continue
+    const key = genre.toLowerCase()
+    if (!seen.has(key)) {
+      seen.add(key)
+      out.push(genre)
+    }
+  }
+  return out
+}
+
+// Normalise une catégorie pour le stockage : genres dédoublonnés rejoints par
+// " / ", ou null si rien d'exploitable.
+export function cleanCategory(category: string | null | undefined): string | null {
+  const genres = splitGenres(category)
+  return genres.length > 0 ? genres.join(' / ') : null
+}

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -1,31 +1,14 @@
 import Image from 'next/image'
+import { splitGenres } from '@/features/works/category'
 import type { WorkCardDto } from '@/features/works/dto'
 import ExpandableDescription from '@/features/works/ui/ExpandableDescription'
 import { formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
-
-// La catégorie brute est souvent dupliquée/concaténée ("drame - drame / road-movie").
-// On découpe sur " / ", " · " et " - " (avec espaces, pour garder "road-movie"), puis on dédoublonne.
-function parseGenres(category: string | null): string[] {
-  if (!category) return []
-  const seen = new Set<string>()
-  const out: string[] = []
-  for (const part of category.split(/\s*[/·]\s*|\s+-\s+/)) {
-    const genre = part.trim()
-    if (!genre) continue
-    const key = genre.toLowerCase()
-    if (!seen.has(key)) {
-      seen.add(key)
-      out.push(genre)
-    }
-  }
-  return out.slice(0, 3)
-}
 
 export default function CardWork({ work }: { work: WorkCardDto }) {
   const durationLabel = formatDuration(work.durationMin)
   const priceLabel = formatPriceRange(work.priceMin, work.priceMax)
   const description = work.description?.trim()
-  const genres = parseGenres(work.category)
+  const genres = splitGenres(work.category).slice(0, 3)
   const sectionLabel = work.section === 'cinema' ? 'Cinéma' : 'Théâtre'
   const directorLabel = work.section === 'cinema' ? 'De' : 'Mise en scène'
   const hasFacts = genres.length > 0 || Boolean(durationLabel) || Boolean(priceLabel)

--- a/app/tests/features/category.test.ts
+++ b/app/tests/features/category.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { cleanCategory, splitGenres } from '@/features/works/category'
+
+describe('splitGenres', () => {
+  it('dédoublonne et préserve les genres composés', () => {
+    expect(splitGenres('drame - drame / road-movie')).toEqual(['drame', 'road-movie'])
+  })
+
+  it('découpe sur " · " et ignore les segments vides', () => {
+    expect(splitGenres('comédie · comédie /  ')).toEqual(['comédie'])
+  })
+
+  it('dédoublonne sans tenir compte de la casse en gardant la 1re graphie', () => {
+    expect(splitGenres('Drame / drame')).toEqual(['Drame'])
+  })
+
+  it('renvoie [] pour null/vide', () => {
+    expect(splitGenres(null)).toEqual([])
+    expect(splitGenres('   ')).toEqual([])
+  })
+})
+
+describe('cleanCategory', () => {
+  it('rejoint les genres nettoyés par " / "', () => {
+    expect(cleanCategory('drame - drame / road-movie')).toBe('drame / road-movie')
+  })
+
+  it('renvoie null quand il ne reste rien', () => {
+    expect(cleanCategory(null)).toBeNull()
+    expect(cleanCategory('   ')).toBeNull()
+  })
+})


### PR DESCRIPTION
Le champ `category` était sale en base (« drame - drame / road-movie ») et nettoyé seulement à l affichage. Cette PR le nettoie **à l ingestion**.

- Nouveau module partagé `features/works/category.ts` : `splitGenres()` (dédup insensible à la casse, genres composés préservés) + `cleanCategory()` (normalisation pour stockage).
- `offi-import/mappers` : `category` nettoyée à la **création et à la mise à jour**.
- `CardWork` réutilise `splitGenres` (suppression de la logique dupliquée).
- Tests unitaires `splitGenres`/`cleanCategory`.

**Données existantes** : one-off appliqué sur Neon → 84/668 catégories normalisées (idempotent vis-à-vis de la logique d affichage).

lint/typecheck verts, tests verts en local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)