### PR TITLE
feat(friends): consentement (demande/acceptation) + retrait d ami

### DIFF
--- a/app/prisma/migrations/20260608090000_add_friendship_status/migration.sql
+++ b/app/prisma/migrations/20260608090000_add_friendship_status/migration.sql
@@ -1,0 +1,6 @@
+-- Consentement côté amitiés (additif, non destructif).
+-- Les amitiés existantes sont déjà mutuelles → ACCEPTED par défaut.
+-- Une demande par email crée désormais une arête PENDING (requester→target)
+-- que le destinataire doit accepter avant que l'amitié ne devienne mutuelle.
+CREATE TYPE "FriendshipStatus" AS ENUM ('PENDING', 'ACCEPTED');
+ALTER TABLE "Friendship" ADD COLUMN "status" "FriendshipStatus" NOT NULL DEFAULT 'ACCEPTED';

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -124,6 +124,11 @@ model Reaction {
   @@index([createdAt])
 }
 
+enum FriendshipStatus {
+  PENDING
+  ACCEPTED
+}
+
 model Friendship {
   id String @id @default(cuid())
 
@@ -133,6 +138,10 @@ model Friendship {
 
   friend   User   @relation("user_friends_friend", fields: [friendId], references: [id], onDelete: Cascade)
   friendId String
+
+  // PENDING : arête unidirectionnelle (demande de userId vers friendId) en attente
+  // d'acceptation. ACCEPTED : amitié confirmée, stockée comme deux arêtes mutuelles.
+  status FriendshipStatus @default(ACCEPTED)
 
   createdAt DateTime @default(now())
 

--- a/app/src/app/api/friends/requests/route.ts
+++ b/app/src/app/api/friends/requests/route.ts
@@ -1,0 +1,42 @@
+import { requireSessionUser, isUnauthorizedError } from '@/features/auth/server/session'
+import { friendRequestActionSchema } from '@/features/friendships/schemas'
+import { acceptFriendRequest, declineFriendRequest } from '@/features/friendships/server/commands'
+import { jsonError, jsonOk } from '@/shared/lib/http'
+import { rateLimit } from '@/shared/lib/rate-limit'
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+// POST /api/friends/requests — accepter ou refuser une demande reçue.
+export async function POST(req: Request) {
+  try {
+    const sessionUser = await requireSessionUser()
+
+    const limit = rateLimit(`friends:${sessionUser.id}`, 30, 60_000)
+    if (!limit.ok) return jsonError('rate_limited', 429)
+
+    const body = await req.json().catch(() => null)
+    const parsed = friendRequestActionSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return jsonError('invalid_friend_input', 400, parsed.error.flatten())
+    }
+
+    if (parsed.data.action === 'accept') {
+      const friend = await acceptFriendRequest({ userId: sessionUser.id, requesterId: parsed.data.requesterId })
+      return jsonOk({ friend })
+    }
+
+    await declineFriendRequest({ userId: sessionUser.id, requesterId: parsed.data.requesterId })
+    return jsonOk({ declined: true })
+  } catch (error) {
+    if (isUnauthorizedError(error)) return jsonError('unauthorized', 401)
+    if (error instanceof Error) {
+      const status = error.message === 'request_not_found' ? 404 : 400
+      return jsonError(error.message, status)
+    }
+    return jsonError('server_error', 500)
+  }
+}

--- a/app/src/app/api/friends/route.ts
+++ b/app/src/app/api/friends/route.ts
@@ -1,8 +1,8 @@
 import { requireSessionUser, isUnauthorizedError } from '@/features/auth/server/session'
-import { addFriendSchema } from '@/features/friendships/schemas'
-import { addFriend } from '@/features/friendships/server/commands'
+import { addFriendSchema, removeFriendSchema } from '@/features/friendships/schemas'
+import { addFriend, removeFriend } from '@/features/friendships/server/commands'
 import { createInviteToken } from '@/features/friendships/server/invite'
-import { listFriends } from '@/features/friendships/server/queries'
+import { listFriends, listIncomingRequests } from '@/features/friendships/server/queries'
 import { jsonError, jsonOk } from '@/shared/lib/http'
 import { rateLimit } from '@/shared/lib/rate-limit'
 
@@ -20,8 +20,11 @@ export async function GET(req: Request) {
       return jsonOk({ token: createInviteToken(sessionUser.id) })
     }
 
-    const friends = await listFriends(sessionUser.id)
-    return jsonOk({ friends })
+    const [friends, requests] = await Promise.all([
+      listFriends(sessionUser.id),
+      listIncomingRequests(sessionUser.id),
+    ])
+    return jsonOk({ friends, requests })
   } catch (error) {
     if (isUnauthorizedError(error)) return jsonError('unauthorized', 401)
     return jsonError('server_error', 500)
@@ -42,19 +45,41 @@ export async function POST(req: Request) {
       return jsonError('invalid_friend_input', 400, parsed.error.flatten())
     }
 
-    const friend = await addFriend({
+    const result = await addFriend({
       userId: sessionUser.id,
       userEmail: sessionUser.email,
       input: parsed.data,
     })
 
-    return jsonOk({ friend }, 200)
+    return jsonOk({ friend: result.friend, status: result.status }, 200)
   } catch (error) {
     if (isUnauthorizedError(error)) return jsonError('unauthorized', 401)
     if (error instanceof Error) {
       const status = error.message === 'friend_not_found' ? 404 : 400
       return jsonError(error.message, status)
     }
+    return jsonError('server_error', 500)
+  }
+}
+
+export async function DELETE(req: Request) {
+  try {
+    const sessionUser = await requireSessionUser()
+
+    const limit = rateLimit(`friends:${sessionUser.id}`, 30, 60_000)
+    if (!limit.ok) return jsonError('rate_limited', 429)
+
+    const { searchParams } = new URL(req.url)
+    const parsed = removeFriendSchema.safeParse({ friendId: searchParams.get('friendId') })
+
+    if (!parsed.success) {
+      return jsonError('invalid_friend_input', 400, parsed.error.flatten())
+    }
+
+    await removeFriend({ userId: sessionUser.id, friendId: parsed.data.friendId })
+    return jsonOk({ removed: true })
+  } catch (error) {
+    if (isUnauthorizedError(error)) return jsonError('unauthorized', 401)
     return jsonError('server_error', 500)
   }
 }

--- a/app/src/app/friends/page.tsx
+++ b/app/src/app/friends/page.tsx
@@ -1,15 +1,16 @@
 import { requireSessionUserOrRedirect } from '@/features/auth/server/session'
 import { createInviteToken } from '@/features/friendships/server/invite'
-import { listFriends } from '@/features/friendships/server/queries'
+import { listFriends, listIncomingRequests } from '@/features/friendships/server/queries'
 import FriendsClient from '@/features/friendships/ui/FriendsClient'
 
 export default async function FriendsPage() {
   const sessionUser = await requireSessionUserOrRedirect()
 
-  const [friends, inviteToken] = await Promise.all([
+  const [friends, requests, inviteToken] = await Promise.all([
     listFriends(sessionUser.id),
+    listIncomingRequests(sessionUser.id),
     Promise.resolve(createInviteToken(sessionUser.id)),
   ])
 
-  return <FriendsClient initialFriends={friends} inviteToken={inviteToken} />
+  return <FriendsClient initialFriends={friends} initialRequests={requests} inviteToken={inviteToken} />
 }

--- a/app/src/features/common/server/queries.ts
+++ b/app/src/features/common/server/queries.ts
@@ -11,8 +11,8 @@ export class FriendshipForbiddenError extends Error {
 }
 
 export async function listCommonLikedWorks(userId: string, friendId: string) {
-  const friendship = await prisma.friendship.findUnique({
-    where: { userId_friendId: { userId, friendId } },
+  const friendship = await prisma.friendship.findFirst({
+    where: { userId, friendId, status: 'ACCEPTED' },
     select: { id: true },
   })
 

--- a/app/src/features/friendships/dto.ts
+++ b/app/src/features/friendships/dto.ts
@@ -2,3 +2,9 @@ export type FriendSummaryDto = {
   id: string
   email: string
 }
+
+// Demande d'amitié reçue, en attente d'acceptation.
+export type FriendRequestDto = {
+  id: string
+  email: string
+}

--- a/app/src/features/friendships/schemas.ts
+++ b/app/src/features/friendships/schemas.ts
@@ -11,3 +11,16 @@ export const friendEmailAddSchema = z.object({
 export const addFriendSchema = z.union([friendInviteAcceptSchema, friendEmailAddSchema])
 
 export type AddFriendInput = z.infer<typeof addFriendSchema>
+
+// Accepter / refuser une demande reçue (de requesterId).
+export const friendRequestActionSchema = z.object({
+  requesterId: z.string().min(1),
+  action: z.enum(['accept', 'decline']),
+})
+
+export type FriendRequestActionInput = z.infer<typeof friendRequestActionSchema>
+
+// Retirer un ami.
+export const removeFriendSchema = z.object({
+  friendId: z.string().min(1),
+})

--- a/app/src/features/friendships/server/commands.ts
+++ b/app/src/features/friendships/server/commands.ts
@@ -10,12 +10,35 @@ type AddFriendCommandInput = {
   input: AddFriendInput
 }
 
-export async function addFriend({ userId, userEmail, input }: AddFriendCommandInput) {
+export type AddFriendResult = {
+  friend: { id: string; email: string }
+  // 'accepted' : amitié mutuelle effective (lien d'invitation, ou demande croisée).
+  // 'pending'  : demande envoyée, en attente d'acceptation par le destinataire.
+  status: 'accepted' | 'pending'
+}
+
+async function makeMutual(userId: string, friendId: string) {
+  await prisma.$transaction([
+    prisma.friendship.upsert({
+      where: { userId_friendId: { userId, friendId } },
+      update: { status: 'ACCEPTED' },
+      create: { userId, friendId, status: 'ACCEPTED' },
+    }),
+    prisma.friendship.upsert({
+      where: { userId_friendId: { userId: friendId, friendId: userId } },
+      update: { status: 'ACCEPTED' },
+      create: { userId: friendId, friendId: userId, status: 'ACCEPTED' },
+    }),
+  ])
+}
+
+export async function addFriend({ userId, userEmail, input }: AddFriendCommandInput): Promise<AddFriendResult> {
   const parsedInput = addFriendSchema.parse(input)
 
   let friend = null as { id: string; email: string } | null
 
   if ('token' in parsedInput) {
+    // Lien d'invitation : double consentement (partage du lien + clic) → amitié directe.
     const invite = verifyInviteToken(parsedInput.token)
     if (invite.userId === userId) {
       throw new Error('cannot_add_self')
@@ -25,33 +48,97 @@ export async function addFriend({ userId, userEmail, input }: AddFriendCommandIn
       where: { id: invite.userId },
       select: { id: true, email: true },
     })
-  } else {
-    if (parsedInput.email === userEmail) {
-      throw new Error('cannot_add_self')
+
+    if (!friend) {
+      throw new Error('friend_not_found')
     }
 
-    friend = await prisma.user.findUnique({
-      where: { email: parsedInput.email },
-      select: { id: true, email: true },
-    })
+    await makeMutual(userId, friend.id)
+    return { friend, status: 'accepted' }
   }
+
+  // Ajout par email : nécessite le consentement du destinataire → demande PENDING.
+  if (parsedInput.email === userEmail) {
+    throw new Error('cannot_add_self')
+  }
+
+  friend = await prisma.user.findUnique({
+    where: { email: parsedInput.email },
+    select: { id: true, email: true },
+  })
 
   if (!friend) {
     throw new Error('friend_not_found')
   }
 
-  await prisma.$transaction([
-    prisma.friendship.upsert({
-      where: { userId_friendId: { userId, friendId: friend.id } },
-      update: {},
-      create: { userId, friendId: friend.id },
-    }),
-    prisma.friendship.upsert({
-      where: { userId_friendId: { userId: friend.id, friendId: userId } },
-      update: {},
-      create: { userId: friend.id, friendId: userId },
-    }),
-  ])
+  // Déjà amis (arête sortante ACCEPTED) → idempotent.
+  const existingOutgoing = await prisma.friendship.findUnique({
+    where: { userId_friendId: { userId, friendId: friend.id } },
+    select: { status: true },
+  })
+  if (existingOutgoing?.status === 'ACCEPTED') {
+    return { friend, status: 'accepted' }
+  }
 
-  return friend
+  // Le destinataire m'a déjà envoyé une demande → on l'accepte (demande croisée).
+  const incoming = await prisma.friendship.findUnique({
+    where: { userId_friendId: { userId: friend.id, friendId: userId } },
+    select: { status: true },
+  })
+  if (incoming?.status === 'PENDING') {
+    await makeMutual(userId, friend.id)
+    return { friend, status: 'accepted' }
+  }
+
+  // Sinon : (ré)affirme une demande sortante en attente.
+  await prisma.friendship.upsert({
+    where: { userId_friendId: { userId, friendId: friend.id } },
+    update: { status: 'PENDING' },
+    create: { userId, friendId: friend.id, status: 'PENDING' },
+  })
+
+  return { friend, status: 'pending' }
+}
+
+// Le destinataire (userId) accepte une demande reçue de requesterId.
+export async function acceptFriendRequest({ userId, requesterId }: { userId: string; requesterId: string }) {
+  const request = await prisma.friendship.findUnique({
+    where: { userId_friendId: { userId: requesterId, friendId: userId } },
+    select: { status: true },
+  })
+
+  if (!request || request.status !== 'PENDING') {
+    throw new Error('request_not_found')
+  }
+
+  const requester = await prisma.user.findUnique({
+    where: { id: requesterId },
+    select: { id: true, email: true },
+  })
+
+  if (!requester) {
+    throw new Error('friend_not_found')
+  }
+
+  await makeMutual(userId, requesterId)
+  return requester
+}
+
+// Le destinataire (userId) refuse une demande reçue de requesterId.
+export async function declineFriendRequest({ userId, requesterId }: { userId: string; requesterId: string }) {
+  await prisma.friendship.deleteMany({
+    where: { userId: requesterId, friendId: userId, status: 'PENDING' },
+  })
+}
+
+// Retire une amitié : supprime les deux arêtes (et toute demande en attente associée).
+export async function removeFriend({ userId, friendId }: { userId: string; friendId: string }) {
+  await prisma.friendship.deleteMany({
+    where: {
+      OR: [
+        { userId, friendId },
+        { userId: friendId, friendId: userId },
+      ],
+    },
+  })
 }

--- a/app/src/features/friendships/server/queries.ts
+++ b/app/src/features/friendships/server/queries.ts
@@ -1,11 +1,11 @@
 import 'server-only'
 
 import { prisma } from '@/server/db'
-import type { FriendSummaryDto } from '@/features/friendships/dto'
+import type { FriendRequestDto, FriendSummaryDto } from '@/features/friendships/dto'
 
 export async function listFriends(userId: string): Promise<FriendSummaryDto[]> {
   const friendships = await prisma.friendship.findMany({
-    where: { userId },
+    where: { userId, status: 'ACCEPTED' },
     select: {
       friend: {
         select: {
@@ -22,4 +22,26 @@ export async function listFriends(userId: string): Promise<FriendSummaryDto[]> {
   })
 
   return friendships.map((friendship) => friendship.friend)
+}
+
+// Demandes reçues en attente : arêtes PENDING dont je suis la cible (friendId).
+export async function listIncomingRequests(userId: string): Promise<FriendRequestDto[]> {
+  const requests = await prisma.friendship.findMany({
+    where: { friendId: userId, status: 'PENDING' },
+    select: {
+      user: {
+        select: {
+          id: true,
+          email: true,
+        },
+      },
+    },
+    orderBy: {
+      user: {
+        email: 'asc',
+      },
+    },
+  })
+
+  return requests.map((request) => request.user)
 }

--- a/app/src/features/friendships/ui/FriendsClient.tsx
+++ b/app/src/features/friendships/ui/FriendsClient.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
-import type { FriendSummaryDto } from '@/features/friendships/dto'
+import type { FriendRequestDto, FriendSummaryDto } from '@/features/friendships/dto'
 import type { WorkCardDto } from '@/features/works/dto'
 import WorkSummaryCard from '@/features/works/ui/WorkSummaryCard'
 import { fetchJson } from '@/shared/lib/fetch-json'
@@ -14,12 +14,16 @@ import SurfaceCard from '@/shared/ui/SurfaceCard'
 
 type FriendsClientProps = {
   initialFriends: FriendSummaryDto[]
+  initialRequests: FriendRequestDto[]
   inviteToken: string
 }
 
 type AddFriendPayload = JsonOk<{
   friend: FriendSummaryDto
+  status: 'accepted' | 'pending'
 }>
+
+type AcceptPayload = JsonOk<{ friend: FriendSummaryDto }>
 
 type CommonPayload = JsonOk<{
   works: WorkCardDto[]
@@ -30,16 +34,18 @@ function formatFriendsError(error: string) {
     case 'unauthorized':
       return 'Session expirée. Recharge la page puis reconnecte-toi.'
     case 'invalid_invite_token':
-      return "Le token d'invitation est invalide."
+      return "Le lien d'invitation est invalide."
     case 'invalid_friend_input':
     case 'invalid_body':
-      return "Entre un email valide ou un token d'invitation."
+      return 'Entre un email valide.'
     case 'expired_invite_token':
-      return "Le token d'invitation a expiré."
+      return "Le lien d'invitation a expiré."
     case 'cannot_add_self':
       return "Tu ne peux pas t'ajouter toi-même."
     case 'friend_not_found':
-      return "Le compte invité n'existe plus."
+      return "Aucun compte Offi ne correspond à cet email."
+    case 'request_not_found':
+      return "Cette demande n'existe plus."
     case 'forbidden':
       return "Cette personne n'est pas encore dans ta liste d'amis."
     default:
@@ -47,17 +53,18 @@ function formatFriendsError(error: string) {
   }
 }
 
-export default function FriendsClient({ initialFriends, inviteToken }: FriendsClientProps) {
+export default function FriendsClient({ initialFriends, initialRequests, inviteToken }: FriendsClientProps) {
   const searchParams = useSearchParams()
   const [friends, setFriends] = useState(initialFriends)
+  const [requests, setRequests] = useState(initialRequests)
   const [commons, setCommons] = useState<CommonPayload['works']>([])
   const [emailInput, setEmailInput] = useState('')
-  const [tokenInput, setTokenInput] = useState(() => searchParams.get('token') ?? '')
   const [error, setError] = useState('')
   const [notice, setNotice] = useState('')
-  const [pending, setPending] = useState<'email' | 'token' | 'copy' | 'common' | null>(null)
+  const [pending, setPending] = useState<string | null>(null)
   const [selectedFriendId, setSelectedFriendId] = useState<string | null>(null)
-  const [addMode, setAddMode] = useState<'email' | 'link' | 'token'>(() => (searchParams.get('token') ? 'token' : 'email'))
+  const [addMode, setAddMode] = useState<'email' | 'link'>('email')
+  const acceptedTokenRef = useRef(false)
 
   const inviteUrl = useMemo(() => {
     if (typeof window === 'undefined' || !inviteToken) return ''
@@ -73,33 +80,42 @@ export default function FriendsClient({ initialFriends, inviteToken }: FriendsCl
     })
   }
 
-  async function addFriendByToken() {
-    if (!tokenInput) return
-
-    setPending('token')
-    setError('')
-    setNotice('')
-    try {
-      const payload = await fetchJson<AddFriendPayload>('/api/friends', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: tokenInput }),
-      })
-      upsertFriend(payload.friend)
-      setTokenInput('')
-      setNotice('Ami ajouté.')
-      if (typeof window !== 'undefined') {
-        const url = new URL(window.location.href)
-        url.searchParams.delete('token')
-        window.history.replaceState({}, '', url)
-      }
-    } catch (requestError) {
-      const message = requestError instanceof Error ? requestError.message : 'unknown_error'
-      setError(formatFriendsError(message))
-    } finally {
-      setPending(null)
-    }
+  function removeRequest(requesterId: string) {
+    setRequests((current) => current.filter((item) => item.id !== requesterId))
   }
+
+  // Arrivée via un lien d'invitation (?token=) → consentement explicite par le clic :
+  // on accepte automatiquement, une seule fois, puis on nettoie l'URL.
+  useEffect(() => {
+    const token = searchParams.get('token')
+    if (!token || acceptedTokenRef.current) return
+    acceptedTokenRef.current = true
+
+    void (async () => {
+      setPending('token')
+      setError('')
+      setNotice('')
+      try {
+        const payload = await fetchJson<AddFriendPayload>('/api/friends', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token }),
+        })
+        upsertFriend(payload.friend)
+        setNotice(`${payload.friend.email} fait désormais partie de tes amis.`)
+      } catch (requestError) {
+        const message = requestError instanceof Error ? requestError.message : 'unknown_error'
+        setError(formatFriendsError(message))
+      } finally {
+        setPending(null)
+        if (typeof window !== 'undefined') {
+          const url = new URL(window.location.href)
+          url.searchParams.delete('token')
+          window.history.replaceState({}, '', url)
+        }
+      }
+    })()
+  }, [searchParams])
 
   async function addFriendByEmail() {
     if (!emailInput) return
@@ -113,9 +129,66 @@ export default function FriendsClient({ initialFriends, inviteToken }: FriendsCl
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: emailInput }),
       })
-      upsertFriend(payload.friend)
+      if (payload.status === 'accepted') {
+        upsertFriend(payload.friend)
+        setNotice(`${payload.friend.email} fait désormais partie de tes amis.`)
+      } else {
+        setNotice(`Invitation envoyée à ${payload.friend.email}. Elle apparaîtra dans tes amis une fois acceptée.`)
+      }
       setEmailInput('')
-      setNotice('Ami ajouté.')
+    } catch (requestError) {
+      const message = requestError instanceof Error ? requestError.message : 'unknown_error'
+      setError(formatFriendsError(message))
+    } finally {
+      setPending(null)
+    }
+  }
+
+  async function respondToRequest(requesterId: string, action: 'accept' | 'decline') {
+    setPending(`${action}:${requesterId}`)
+    setError('')
+    setNotice('')
+    try {
+      if (action === 'accept') {
+        const payload = await fetchJson<AcceptPayload>('/api/friends/requests', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ requesterId, action }),
+        })
+        upsertFriend(payload.friend)
+        removeRequest(requesterId)
+        setNotice(`${payload.friend.email} fait désormais partie de tes amis.`)
+      } else {
+        await fetchJson<JsonOk<{ declined: boolean }>>('/api/friends/requests', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ requesterId, action }),
+        })
+        removeRequest(requesterId)
+        setNotice('Demande refusée.')
+      }
+    } catch (requestError) {
+      const message = requestError instanceof Error ? requestError.message : 'unknown_error'
+      setError(formatFriendsError(message))
+    } finally {
+      setPending(null)
+    }
+  }
+
+  async function removeFriendById(friend: FriendSummaryDto) {
+    setPending(`remove:${friend.id}`)
+    setError('')
+    setNotice('')
+    try {
+      await fetchJson<JsonOk<{ removed: boolean }>>(`/api/friends?friendId=${encodeURIComponent(friend.id)}`, {
+        method: 'DELETE',
+      })
+      setFriends((current) => current.filter((item) => item.id !== friend.id))
+      if (selectedFriendId === friend.id) {
+        setSelectedFriendId(null)
+        setCommons([])
+      }
+      setNotice(`${friend.email} a été retiré de tes amis.`)
     } catch (requestError) {
       const message = requestError instanceof Error ? requestError.message : 'unknown_error'
       setError(formatFriendsError(message))
@@ -167,11 +240,11 @@ export default function FriendsClient({ initialFriends, inviteToken }: FriendsCl
       <PageHeader
         eyebrow="Réseau"
         title="Amis"
-        description="Ajoute une personne par email, par lien ou avec un token, puis ouvre directement les oeuvres communes depuis sa ligne pour garder le contexte."
+        description="Invite quelqu'un par email ou par lien : la personne doit accepter avant que vous ne deveniez amis. Ouvre ensuite vos œuvres communes directement depuis sa ligne."
         meta={
           <>
             <span className="chip">{friends.length} ami{friends.length > 1 ? 's' : ''}</span>
-            <span className="chip">{inviteToken ? 'Lien d’invitation prêt' : 'Lien indisponible'}</span>
+            {requests.length > 0 ? <span className="chip">{requests.length} demande{requests.length > 1 ? 's' : ''} en attente</span> : null}
           </>
         }
       />
@@ -186,29 +259,28 @@ export default function FriendsClient({ initialFriends, inviteToken }: FriendsCl
               <p className="text-sm font-semibold uppercase tracking-[0.08em] text-[color:var(--color-accent)]">
                 Ajouter un ami
               </p>
-              <h2 className="text-2xl font-semibold tracking-[-0.03em]">Choisis un seul mode d’invitation à la fois</h2>
+              <h2 className="text-2xl font-semibold tracking-[-0.03em]">Avec son consentement</h2>
               <p className="text-sm leading-7 text-muted-foreground">
-                Le plus simple reste l&apos;email. Le lien et le token servent surtout pour un partage plus ponctuel.
+                Par email, la personne reçoit une demande à accepter. Par lien, elle confirme en l&apos;ouvrant.
               </p>
             </div>
 
             <SegmentedControl
               ariaLabel="Choisir un mode d'ajout"
               value={addMode}
-              onChange={(value) => setAddMode(value as 'email' | 'link' | 'token')}
+              onChange={(value) => setAddMode(value as 'email' | 'link')}
               fullWidth
               items={[
                 { label: 'Par email', value: 'email' },
                 { label: 'Par lien', value: 'link' },
-                { label: 'Par token', value: 'token' },
               ]}
             />
 
             {addMode === 'email' ? (
               <div className="space-y-4">
                 <div className="space-y-1">
-                  <label className="label">Ajouter par email</label>
-                  <p className="field-hint">Le plus simple si tu connais l&apos;email exact de la personne.</p>
+                  <label className="label">Inviter par email</label>
+                  <p className="field-hint">La personne devra accepter ta demande pour devenir ton amie.</p>
                 </div>
                 <div className="flex flex-col gap-3 sm:flex-row">
                   <input
@@ -219,18 +291,16 @@ export default function FriendsClient({ initialFriends, inviteToken }: FriendsCl
                     onChange={(event) => setEmailInput(event.target.value)}
                   />
                   <button className="btn btn-primary" onClick={() => void addFriendByEmail()} disabled={!emailInput || pending !== null}>
-                    {pending === 'email' ? 'Ajout…' : 'Ajouter'}
+                    {pending === 'email' ? 'Envoi…' : 'Inviter'}
                   </button>
                 </div>
               </div>
-            ) : null}
-
-            {addMode === 'link' ? (
+            ) : (
               <div className="space-y-4">
                 <div className="space-y-1">
                   <label className="label">Mon lien d&apos;invitation</label>
                   <p className="field-hint">
-                    Pratique si tu ne veux pas partager ton email ou si l&apos;autre personne préfère ouvrir un lien.
+                    Partage ce lien : la personne devient ton amie en l&apos;ouvrant (le lien expire au bout de 24&nbsp;h).
                   </p>
                 </div>
                 <div className="flex flex-col gap-3 sm:flex-row">
@@ -240,36 +310,52 @@ export default function FriendsClient({ initialFriends, inviteToken }: FriendsCl
                   </button>
                 </div>
               </div>
-            ) : null}
+            )}
+          </SurfaceCard>
 
-            {addMode === 'token' ? (
-              <div className="space-y-4">
-                <div className="space-y-1">
-                  <label className="label">Ajouter avec un token</label>
-                  <p className="field-hint">Colle le token reçu pour valider l&apos;invitation immédiatement.</p>
-                </div>
-                <div className="flex flex-col gap-3 sm:flex-row">
-                  <input
-                    className="input flex-1"
-                    placeholder="token reçu"
-                    value={tokenInput}
-                    onChange={(event) => setTokenInput(event.target.value)}
-                  />
-                  <button className="btn btn-primary" onClick={() => void addFriendByToken()} disabled={!tokenInput || pending !== null}>
-                    {pending === 'token' ? 'Ajout…' : 'Ajouter'}
-                  </button>
-                </div>
+          {requests.length > 0 ? (
+            <SurfaceCard tone="muted" className="space-y-4">
+              <div className="space-y-1">
+                <h2 className="text-xl font-semibold tracking-[-0.03em]">Demandes reçues</h2>
+                <p className="text-sm leading-7 text-muted-foreground">Ces personnes souhaitent t&apos;ajouter en ami.</p>
               </div>
-            ) : null}
-          </SurfaceCard>
-
-          <SurfaceCard tone="muted" className="space-y-3">
-            <p className="text-sm font-semibold uppercase tracking-[0.08em] text-[color:var(--color-accent)]">Conseil</p>
-            <p className="text-sm leading-7 text-muted-foreground">
-              Une fois l&apos;ami ajouté, ouvre ses oeuvres en commun directement depuis sa ligne. Cela garde la comparaison
-              visible sans te faire descendre sur une autre section de page.
-            </p>
-          </SurfaceCard>
+              <ul className="space-y-3">
+                {requests.map((request) => {
+                  const isAccepting = pending === `accept:${request.id}`
+                  const isDeclining = pending === `decline:${request.id}`
+                  return (
+                    <li
+                      key={request.id}
+                      className="flex flex-col gap-3 rounded-[1.4rem] border border-[color:var(--color-border)] bg-white/72 p-4 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[rgba(15,93,94,0.12)] text-sm font-semibold text-[color:var(--color-accent)]">
+                          {initialsFromEmail(request.email)}
+                        </div>
+                        <div className="text-sm font-semibold tracking-[-0.02em]">{request.email}</div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          className="btn btn-primary px-3 py-1.5 text-xs"
+                          onClick={() => void respondToRequest(request.id, 'accept')}
+                          disabled={pending !== null}
+                        >
+                          {isAccepting ? 'Ajout…' : 'Accepter'}
+                        </button>
+                        <button
+                          className="btn btn-ghost px-3 py-1.5 text-xs"
+                          onClick={() => void respondToRequest(request.id, 'decline')}
+                          disabled={pending !== null}
+                        >
+                          {isDeclining ? 'Refus…' : 'Refuser'}
+                        </button>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            </SurfaceCard>
+          ) : null}
         </div>
 
         <SurfaceCard className="space-y-5">
@@ -286,13 +372,14 @@ export default function FriendsClient({ initialFriends, inviteToken }: FriendsCl
           {friends.length === 0 ? (
             <div className="empty-state rounded-[1.5rem] border border-dashed border-[color:var(--color-border)] bg-white/45">
               <strong>Aucun ami pour le moment.</strong>
-              <p className="text-sm leading-7 text-muted-foreground">Commence par partager ton lien ou par saisir un email.</p>
+              <p className="text-sm leading-7 text-muted-foreground">Commence par partager ton lien ou par inviter un email.</p>
             </div>
           ) : (
             <ul className="space-y-4">
               {friends.map((friend) => {
                 const isExpanded = selectedFriendId === friend.id
                 const isLoadingCommon = pending === 'common' && isExpanded
+                const isRemoving = pending === `remove:${friend.id}`
 
                 return (
                   <li
@@ -306,17 +393,27 @@ export default function FriendsClient({ initialFriends, inviteToken }: FriendsCl
                         </div>
                         <div>
                           <div className="text-base font-semibold tracking-[-0.02em]">{friend.email}</div>
-                          <div className="text-sm text-muted-foreground">Découvre vos oeuvres communes sans quitter cette ligne.</div>
+                          <div className="text-sm text-muted-foreground">Découvre vos œuvres communes sans quitter cette ligne.</div>
                         </div>
                       </div>
 
-                      <button
-                        className={`btn ${isExpanded ? 'btn-primary' : 'btn-secondary'}`}
-                        onClick={() => void loadCommon(friend.id)}
-                        disabled={pending !== null && !isLoadingCommon}
-                      >
-                        {isLoadingCommon ? 'Chargement…' : isExpanded ? 'Masquer les oeuvres en commun' : 'Œuvres en commun'}
-                      </button>
+                      <div className="flex items-center gap-2">
+                        <button
+                          className={`btn ${isExpanded ? 'btn-primary' : 'btn-secondary'}`}
+                          onClick={() => void loadCommon(friend.id)}
+                          disabled={pending !== null && !isLoadingCommon}
+                        >
+                          {isLoadingCommon ? 'Chargement…' : isExpanded ? 'Masquer les œuvres en commun' : 'Œuvres en commun'}
+                        </button>
+                        <button
+                          className="btn btn-ghost px-3 py-1.5 text-xs"
+                          onClick={() => void removeFriendById(friend)}
+                          disabled={pending !== null}
+                          aria-label={`Retirer ${friend.email}`}
+                        >
+                          {isRemoving ? 'Retrait…' : 'Retirer'}
+                        </button>
+                      </div>
                     </div>
 
                     {isExpanded ? (

--- a/app/tests/api-friend-requests.test.ts
+++ b/app/tests/api-friend-requests.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { requireSessionUserMock, acceptMock, declineMock } = vi.hoisted(() => ({
+  requireSessionUserMock: vi.fn(),
+  acceptMock: vi.fn(),
+  declineMock: vi.fn(),
+}))
+
+vi.mock('@/features/auth/server/session', () => ({
+  requireSessionUser: requireSessionUserMock,
+  isUnauthorizedError: (error: unknown) => error instanceof Error && error.message === 'unauthorized',
+}))
+
+vi.mock('@/features/friendships/server/commands', () => ({
+  acceptFriendRequest: acceptMock,
+  declineFriendRequest: declineMock,
+}))
+
+import { POST } from '@/app/api/friends/requests/route'
+
+function post(body: unknown) {
+  return POST(
+    new Request('http://localhost/api/friends/requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
+describe('/api/friends/requests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    requireSessionUserMock.mockResolvedValue({ id: 'me', email: 'me@example.com' })
+  })
+
+  it('accepts a request and returns the friend', async () => {
+    acceptMock.mockResolvedValue({ id: 'req-1', email: 'req@example.com' })
+
+    const response = await post({ requesterId: 'req-1', action: 'accept' })
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual({ ok: true, friend: { id: 'req-1', email: 'req@example.com' } })
+    expect(acceptMock).toHaveBeenCalledWith({ userId: 'me', requesterId: 'req-1' })
+  })
+
+  it('declines a request', async () => {
+    declineMock.mockResolvedValue(undefined)
+
+    const response = await post({ requesterId: 'req-1', action: 'decline' })
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual({ ok: true, declined: true })
+    expect(declineMock).toHaveBeenCalledWith({ userId: 'me', requesterId: 'req-1' })
+  })
+
+  it('returns 404 when the request no longer exists', async () => {
+    acceptMock.mockRejectedValue(new Error('request_not_found'))
+
+    const response = await post({ requesterId: 'req-1', action: 'accept' })
+    const payload = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(payload).toEqual({ ok: false, error: 'request_not_found' })
+  })
+
+  it('returns 400 on invalid body', async () => {
+    const response = await post({ requesterId: '', action: 'nope' })
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload).toMatchObject({ ok: false, error: 'invalid_friend_input' })
+  })
+})

--- a/app/tests/api-friends.test.ts
+++ b/app/tests/api-friends.test.ts
@@ -1,10 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { requireSessionUserMock, createInviteTokenMock, listFriendsMock, addFriendMock } = vi.hoisted(() => ({
+const {
+  requireSessionUserMock,
+  createInviteTokenMock,
+  listFriendsMock,
+  listIncomingRequestsMock,
+  addFriendMock,
+  removeFriendMock,
+} = vi.hoisted(() => ({
   requireSessionUserMock: vi.fn(),
   createInviteTokenMock: vi.fn(),
   listFriendsMock: vi.fn(),
+  listIncomingRequestsMock: vi.fn(),
   addFriendMock: vi.fn(),
+  removeFriendMock: vi.fn(),
 }))
 
 vi.mock('@/features/auth/server/session', () => ({
@@ -18,22 +27,25 @@ vi.mock('@/features/friendships/server/invite', () => ({
 
 vi.mock('@/features/friendships/server/queries', () => ({
   listFriends: listFriendsMock,
+  listIncomingRequests: listIncomingRequestsMock,
 }))
 
 vi.mock('@/features/friendships/server/commands', () => ({
   addFriend: addFriendMock,
+  removeFriend: removeFriendMock,
 }))
 
-import { GET, POST } from '@/app/api/friends/route'
+import { DELETE, GET, POST } from '@/app/api/friends/route'
 
 describe('/api/friends', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('returns only public friend fields', async () => {
+  it('returns public friend fields and pending requests', async () => {
     requireSessionUserMock.mockResolvedValue({ id: 'me', email: 'me@example.com' })
     listFriendsMock.mockResolvedValue([{ id: 'friend-1', email: 'friend@example.com' }])
+    listIncomingRequestsMock.mockResolvedValue([{ id: 'req-1', email: 'req@example.com' }])
 
     const response = await GET(new Request('http://localhost/api/friends'))
     const payload = await response.json()
@@ -42,8 +54,10 @@ describe('/api/friends', () => {
     expect(payload).toEqual({
       ok: true,
       friends: [{ id: 'friend-1', email: 'friend@example.com' }],
+      requests: [{ id: 'req-1', email: 'req@example.com' }],
     })
     expect(listFriendsMock).toHaveBeenCalledWith('me')
+    expect(listIncomingRequestsMock).toHaveBeenCalledWith('me')
   })
 
   it('returns an invite token for the authenticated user', async () => {
@@ -91,9 +105,9 @@ describe('/api/friends', () => {
     expect(payload).toEqual({ ok: false, error: 'friend_not_found' })
   })
 
-  it('returns the added friend on success', async () => {
+  it('returns the added friend and status on success', async () => {
     requireSessionUserMock.mockResolvedValue({ id: 'me', email: 'me@example.com' })
-    addFriendMock.mockResolvedValue({ id: 'friend-1', email: 'friend@example.com' })
+    addFriendMock.mockResolvedValue({ friend: { id: 'friend-1', email: 'friend@example.com' }, status: 'accepted' })
 
     const response = await POST(
       new Request('http://localhost/api/friends', {
@@ -108,11 +122,55 @@ describe('/api/friends', () => {
     expect(payload).toEqual({
       ok: true,
       friend: { id: 'friend-1', email: 'friend@example.com' },
+      status: 'accepted',
     })
     expect(addFriendMock).toHaveBeenCalledWith({
       userId: 'me',
       userEmail: 'me@example.com',
       input: { token: 'x'.repeat(32) },
     })
+  })
+
+  it('returns pending status for an email invitation', async () => {
+    requireSessionUserMock.mockResolvedValue({ id: 'me', email: 'me@example.com' })
+    addFriendMock.mockResolvedValue({ friend: { id: 'friend-2', email: 'new@example.com' }, status: 'pending' })
+
+    const response = await POST(
+      new Request('http://localhost/api/friends', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'new@example.com' }),
+      }),
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual({
+      ok: true,
+      friend: { id: 'friend-2', email: 'new@example.com' },
+      status: 'pending',
+    })
+  })
+
+  it('removes a friend via DELETE', async () => {
+    requireSessionUserMock.mockResolvedValue({ id: 'me', email: 'me@example.com' })
+    removeFriendMock.mockResolvedValue(undefined)
+
+    const response = await DELETE(new Request('http://localhost/api/friends?friendId=friend-1', { method: 'DELETE' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual({ ok: true, removed: true })
+    expect(removeFriendMock).toHaveBeenCalledWith({ userId: 'me', friendId: 'friend-1' })
+  })
+
+  it('rejects DELETE without friendId', async () => {
+    requireSessionUserMock.mockResolvedValue({ id: 'me', email: 'me@example.com' })
+
+    const response = await DELETE(new Request('http://localhost/api/friends', { method: 'DELETE' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload).toMatchObject({ ok: false, error: 'invalid_friend_input' })
   })
 })

--- a/app/tests/features/friendships-command.test.ts
+++ b/app/tests/features/friendships-command.test.ts
@@ -7,6 +7,8 @@ const { prisma, verifyInviteTokenMock } = vi.hoisted(() => ({
     },
     friendship: {
       upsert: vi.fn(),
+      findUnique: vi.fn(),
+      deleteMany: vi.fn(),
     },
     $transaction: vi.fn(),
   },
@@ -18,27 +20,29 @@ vi.mock('@/features/friendships/server/invite', () => ({
   verifyInviteToken: verifyInviteTokenMock,
 }))
 
-import { addFriend } from '@/features/friendships/server/commands'
+import {
+  acceptFriendRequest,
+  addFriend,
+  declineFriendRequest,
+  removeFriend,
+} from '@/features/friendships/server/commands'
 
 describe('addFriend', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     prisma.$transaction.mockImplementation(async (operations: Array<Promise<unknown>>) => Promise.all(operations))
+    prisma.friendship.findUnique.mockResolvedValue(null)
   })
 
   it('rejects adding yourself via invite token', async () => {
     verifyInviteTokenMock.mockReturnValue({ userId: 'me' })
 
     await expect(
-      addFriend({
-        userId: 'me',
-        userEmail: 'me@example.com',
-        input: { token: 'x'.repeat(32) },
-      }),
+      addFriend({ userId: 'me', userEmail: 'me@example.com', input: { token: 'x'.repeat(32) } }),
     ).rejects.toThrow('cannot_add_self')
   })
 
-  it('creates the two symmetric friendship rows', async () => {
+  it('invite token → amitié mutuelle ACCEPTED', async () => {
     verifyInviteTokenMock.mockReturnValue({ userId: 'friend-1' })
     prisma.user.findUnique.mockResolvedValue({ id: 'friend-1', email: 'friend@example.com' })
     prisma.friendship.upsert.mockResolvedValue({})
@@ -49,11 +53,12 @@ describe('addFriend', () => {
       input: { token: 'x'.repeat(32) },
     })
 
-    expect(result).toEqual({ id: 'friend-1', email: 'friend@example.com' })
+    expect(result).toEqual({ friend: { id: 'friend-1', email: 'friend@example.com' }, status: 'accepted' })
     expect(prisma.friendship.upsert).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
         where: { userId_friendId: { userId: 'me', friendId: 'friend-1' } },
+        create: { userId: 'me', friendId: 'friend-1', status: 'ACCEPTED' },
       }),
     )
     expect(prisma.friendship.upsert).toHaveBeenNthCalledWith(
@@ -62,5 +67,119 @@ describe('addFriend', () => {
         where: { userId_friendId: { userId: 'friend-1', friendId: 'me' } },
       }),
     )
+  })
+
+  it('email → demande PENDING (consentement requis)', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'friend-1', email: 'friend@example.com' })
+    prisma.friendship.findUnique.mockResolvedValue(null)
+    prisma.friendship.upsert.mockResolvedValue({})
+
+    const result = await addFriend({
+      userId: 'me',
+      userEmail: 'me@example.com',
+      input: { email: 'friend@example.com' },
+    })
+
+    expect(result).toEqual({ friend: { id: 'friend-1', email: 'friend@example.com' }, status: 'pending' })
+    expect(prisma.friendship.upsert).toHaveBeenCalledTimes(1)
+    expect(prisma.friendship.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId_friendId: { userId: 'me', friendId: 'friend-1' } },
+        create: { userId: 'me', friendId: 'friend-1', status: 'PENDING' },
+      }),
+    )
+  })
+
+  it('email → demande croisée : si l’autre m’a déjà invité, on accepte', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'friend-1', email: 'friend@example.com' })
+    // 1er findUnique (arête sortante) → null ; 2e (arête entrante) → PENDING
+    prisma.friendship.findUnique.mockResolvedValueOnce(null).mockResolvedValueOnce({ status: 'PENDING' })
+    prisma.friendship.upsert.mockResolvedValue({})
+
+    const result = await addFriend({
+      userId: 'me',
+      userEmail: 'me@example.com',
+      input: { email: 'friend@example.com' },
+    })
+
+    expect(result.status).toBe('accepted')
+    expect(prisma.friendship.upsert).toHaveBeenCalledTimes(2)
+  })
+
+  it('email → déjà amis : idempotent (accepted, pas d’upsert)', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: 'friend-1', email: 'friend@example.com' })
+    prisma.friendship.findUnique.mockResolvedValueOnce({ status: 'ACCEPTED' })
+
+    const result = await addFriend({
+      userId: 'me',
+      userEmail: 'me@example.com',
+      input: { email: 'friend@example.com' },
+    })
+
+    expect(result.status).toBe('accepted')
+    expect(prisma.friendship.upsert).not.toHaveBeenCalled()
+  })
+
+  it('email → compte introuvable', async () => {
+    prisma.user.findUnique.mockResolvedValue(null)
+
+    await expect(
+      addFriend({ userId: 'me', userEmail: 'me@example.com', input: { email: 'ghost@example.com' } }),
+    ).rejects.toThrow('friend_not_found')
+  })
+})
+
+describe('acceptFriendRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    prisma.$transaction.mockImplementation(async (operations: Array<Promise<unknown>>) => Promise.all(operations))
+  })
+
+  it('accepte une demande PENDING reçue → mutuelle', async () => {
+    prisma.friendship.findUnique.mockResolvedValue({ status: 'PENDING' })
+    prisma.user.findUnique.mockResolvedValue({ id: 'req-1', email: 'req@example.com' })
+    prisma.friendship.upsert.mockResolvedValue({})
+
+    const friend = await acceptFriendRequest({ userId: 'me', requesterId: 'req-1' })
+
+    expect(friend).toEqual({ id: 'req-1', email: 'req@example.com' })
+    expect(prisma.friendship.findUnique).toHaveBeenCalledWith({
+      where: { userId_friendId: { userId: 'req-1', friendId: 'me' } },
+      select: { status: true },
+    })
+    expect(prisma.friendship.upsert).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejette si aucune demande en attente', async () => {
+    prisma.friendship.findUnique.mockResolvedValue(null)
+
+    await expect(acceptFriendRequest({ userId: 'me', requesterId: 'req-1' })).rejects.toThrow('request_not_found')
+  })
+})
+
+describe('declineFriendRequest / removeFriend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('decline supprime l’arête PENDING entrante', async () => {
+    prisma.friendship.deleteMany.mockResolvedValue({ count: 1 })
+    await declineFriendRequest({ userId: 'me', requesterId: 'req-1' })
+    expect(prisma.friendship.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 'req-1', friendId: 'me', status: 'PENDING' },
+    })
+  })
+
+  it('removeFriend supprime les deux arêtes', async () => {
+    prisma.friendship.deleteMany.mockResolvedValue({ count: 2 })
+    await removeFriend({ userId: 'me', friendId: 'friend-1' })
+    expect(prisma.friendship.deleteMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { userId: 'me', friendId: 'friend-1' },
+          { userId: 'friend-1', friendId: 'me' },
+        ],
+      },
+    })
   })
 })

--- a/app/tests/friends-client.test.tsx
+++ b/app/tests/friends-client.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 vi.mock('next/navigation', () => ({
@@ -8,60 +8,99 @@ vi.mock('next/navigation', () => ({
 
 import FriendsClient from '@/features/friendships/ui/FriendsClient'
 
+function jsonResponse(payload: unknown) {
+  return { ok: true, text: async () => JSON.stringify(payload) } as Response
+}
+
 describe('FriendsClient', () => {
   beforeEach(() => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      text: async () => JSON.stringify({ ok: true, friend: { id: 'friend-2', email: 'new@example.com' } }),
-    } as Response)
+    vi.mocked(fetch).mockReset()
   })
 
-  it('adds a friend by email and updates the list', async () => {
+  it('invite par email → demande en attente (consentement), notice explicite', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ ok: true, friend: { id: 'friend-2', email: 'new@example.com' }, status: 'pending' }),
+    )
     const user = userEvent.setup()
-    render(<FriendsClient initialFriends={[]} inviteToken="token-1" />)
+    render(<FriendsClient initialFriends={[]} initialRequests={[]} inviteToken="token-1" />)
 
     await user.type(screen.getByPlaceholderText('email@exemple.com'), 'new@example.com')
-    await user.click(screen.getAllByRole('button', { name: 'Ajouter' })[0])
+    await user.click(screen.getByRole('button', { name: 'Inviter' }))
 
     expect(fetch).toHaveBeenCalledWith(
       '/api/friends',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ email: 'new@example.com' }),
-      }),
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ email: 'new@example.com' }) }),
     )
-    expect(await screen.findByText('new@example.com')).toBeInTheDocument()
+    expect(await screen.findByText(/Invitation envoyée à new@example.com/i)).toBeInTheDocument()
+    // pas ajouté à la liste d'amis tant que non accepté
+    expect(screen.queryByText('Aucun ami pour le moment.')).toBeInTheDocument()
+  }, 15000)
+
+  it('accepter une demande reçue la déplace dans Mes amis', async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ ok: true, friend: { id: 'req-1', email: 'req@example.com' } }))
+    const user = userEvent.setup()
+    render(
+      <FriendsClient initialFriends={[]} initialRequests={[{ id: 'req-1', email: 'req@example.com' }]} inviteToken="token-1" />,
+    )
+
+    expect(screen.getByText('Demandes reçues')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Accepter' }))
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/friends/requests',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ requesterId: 'req-1', action: 'accept' }) }),
+    )
+    await waitFor(() => expect(screen.queryByText('Demandes reçues')).not.toBeInTheDocument())
+    expect(screen.getByText('req@example.com')).toBeInTheDocument()
+  }, 15000)
+
+  it('retirer un ami le supprime de la liste', async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ ok: true, removed: true }))
+    const user = userEvent.setup()
+    render(
+      <FriendsClient initialFriends={[{ id: 'friend-1', email: 'friend@example.com' }]} initialRequests={[]} inviteToken="token-1" />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Retirer friend@example.com' }))
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/friends?friendId=friend-1',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+    await waitFor(() => expect(screen.queryByText('friend@example.com')).not.toBeInTheDocument())
   }, 15000)
 
   it('loads common works inline for a selected friend', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: true,
-      text: async () =>
-        JSON.stringify({
-          ok: true,
-          works: [
-            {
-              id: 'work-1',
-              title: 'Hamlet',
-              section: 'theatre',
-              imageUrl: null,
-              category: null,
-              venue: 'Comédie-Française',
-              address: null,
-              description: null,
-              startDate: '2026-03-01T00:00:00.000Z',
-              endDate: '2026-03-30T00:00:00.000Z',
-              durationMin: 120,
-              priceMin: 18,
-              priceMax: 42,
-              sourceUrl: 'https://www.offi.fr/hamlet',
-            },
-          ],
-        }),
-    } as Response)
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        works: [
+          {
+            id: 'work-1',
+            title: 'Hamlet',
+            section: 'theatre',
+            imageUrl: null,
+            category: null,
+            venue: 'Comédie-Française',
+            address: null,
+            description: null,
+            startDate: '2026-03-01T00:00:00.000Z',
+            endDate: '2026-03-30T00:00:00.000Z',
+            durationMin: 120,
+            priceMin: 18,
+            priceMax: 42,
+            director: null,
+            cast: [],
+            sourceUrl: 'https://www.offi.fr/hamlet',
+          },
+        ],
+      }),
+    )
 
     const user = userEvent.setup()
-    render(<FriendsClient initialFriends={[{ id: 'friend-1', email: 'friend@example.com' }]} inviteToken="token-1" />)
+    render(
+      <FriendsClient initialFriends={[{ id: 'friend-1', email: 'friend@example.com' }]} initialRequests={[]} inviteToken="token-1" />,
+    )
 
     await user.click(screen.getByRole('button', { name: /œuvres en commun/i }))
 


### PR DESCRIPTION
Refonte UX amis (audit) — passage à un modèle **avec consentement**.

## Comportement
- **3 modes → 2** : email + lien (le mode « token » manuel est supprimé).
- **Consentement** :
  - Par **email** → crée une **demande en attente** (PENDING) que le destinataire doit **accepter/refuser**. Pas d amitié ni d œuvres communes tant que non accepté.
  - Par **lien** d invitation → ajout mutuel direct (double consentement : partage du lien + clic), **auto-accepté** à l ouverture de `?token=`.
  - Demande **croisée** (les deux s invitent) → auto-acceptée.
- Nouvelle section **« Demandes reçues »** (accepter / refuser).
- **Retrait d ami** (bouton « Retirer » → `DELETE /api/friends`).
- La garde **« œuvres en commun »** exige désormais une amitié `ACCEPTED`.

## Technique
- Migration additive `20260608090000_add_friendship_status` (enum `PENDING`/`ACCEPTED`, défaut `ACCEPTED` → **amitiés existantes intactes**). **Appliquée sur Neon** (4 amitiés, toutes ACCEPTED).
- `commands` : `addFriend` (token→mutuel / email→pending), `acceptFriendRequest`, `declineFriendRequest`, `removeFriend`. `queries` : `listIncomingRequests`.
- Routes : `POST /api/friends/requests`, `DELETE /api/friends`.
- **Tests** : commands (10), api-friends (8), api-friends/requests (4), client (4). lint/typecheck verts ; couverture lines 57.7 / func 60.8 / branches 53.7 (seuils 45/48/44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)