### PR TITLE
style(ui): aligner les rayons inline sur une échelle de tokens

### DIFF
--- a/app/src/app/(auth)/signin/page.tsx
+++ b/app/src/app/(auth)/signin/page.tsx
@@ -10,7 +10,7 @@ import SurfaceCard from '@/shared/ui/SurfaceCard'
 
 export default function SignInPage() {
   return (
-    <Suspense fallback={<div className="skeleton h-[28rem] rounded-[1.75rem]" />}>
+    <Suspense fallback={<div className="skeleton h-[28rem] rounded-[var(--radius-xl)]" />}>
       <SignInInner />
     </Suspense>
   )

--- a/app/src/app/discover/loading.tsx
+++ b/app/src/app/discover/loading.tsx
@@ -4,18 +4,18 @@ export default function LoadingDiscover() {
       <div className="page-header">
         <div className="space-y-3">
           <div className="skeleton h-4 w-28 rounded-full" />
-          <div className="skeleton h-12 w-64 rounded-[1.25rem]" />
+          <div className="skeleton h-12 w-64 rounded-[var(--radius-md)]" />
           <div className="skeleton h-5 w-full max-w-2xl rounded-full" />
         </div>
       </div>
 
-      <div className="mx-auto w-full max-w-xl rounded-[2rem] border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3 shadow-[var(--shadow-lg)]">
-        <div className="skeleton h-[26rem] rounded-[1.6rem]" />
+      <div className="mx-auto w-full max-w-xl rounded-[var(--radius-2xl)] border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-3 shadow-[var(--shadow-lg)]">
+        <div className="skeleton h-[26rem] rounded-[var(--radius-lg)]" />
         <div className="mt-4 grid gap-3 sm:grid-cols-2">
-          <div className="skeleton h-20 rounded-[1.2rem]" />
-          <div className="skeleton h-20 rounded-[1.2rem]" />
-          <div className="skeleton h-20 rounded-[1.2rem]" />
-          <div className="skeleton h-20 rounded-[1.2rem]" />
+          <div className="skeleton h-20 rounded-[var(--radius-md)]" />
+          <div className="skeleton h-20 rounded-[var(--radius-md)]" />
+          <div className="skeleton h-20 rounded-[var(--radius-md)]" />
+          <div className="skeleton h-20 rounded-[var(--radius-md)]" />
         </div>
       </div>
     </div>

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -20,8 +20,14 @@
   --color-success-soft: #e8f4ed;
   --shadow-sm: 0 2px 8px rgba(54, 39, 24, 0.06);
   --shadow-lg: 0 8px 24px rgba(54, 39, 24, 0.09);
-  --radius-panel: 1rem;
+  /* Échelle de rayons (du plus petit au plus grand). Les composants doivent
+     piocher dans cette échelle plutôt que de coder des valeurs en dur. */
   --radius-control: 0.7rem;
+  --radius-panel: 1rem;
+  --radius-md: 1.25rem;
+  --radius-lg: 1.5rem;
+  --radius-xl: 1.85rem;
+  --radius-2xl: 2rem;
 }
 
 * {

--- a/app/src/features/friendships/ui/FriendsClient.tsx
+++ b/app/src/features/friendships/ui/FriendsClient.tsx
@@ -326,7 +326,7 @@ export default function FriendsClient({ initialFriends, initialRequests, inviteT
                   return (
                     <li
                       key={request.id}
-                      className="flex flex-col gap-3 rounded-[1.4rem] border border-[color:var(--color-border)] bg-white/72 p-4 sm:flex-row sm:items-center sm:justify-between"
+                      className="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-[color:var(--color-border)] bg-white/72 p-4 sm:flex-row sm:items-center sm:justify-between"
                     >
                       <div className="flex items-center gap-3">
                         <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[rgba(15,93,94,0.12)] text-sm font-semibold text-[color:var(--color-accent)]">
@@ -370,7 +370,7 @@ export default function FriendsClient({ initialFriends, initialRequests, inviteT
           </div>
 
           {friends.length === 0 ? (
-            <div className="empty-state rounded-[1.5rem] border border-dashed border-[color:var(--color-border)] bg-white/45">
+            <div className="empty-state rounded-[var(--radius-lg)] border border-dashed border-[color:var(--color-border)] bg-white/45">
               <strong>Aucun ami pour le moment.</strong>
               <p className="text-sm leading-7 text-muted-foreground">Commence par partager ton lien ou par inviter un email.</p>
             </div>
@@ -384,7 +384,7 @@ export default function FriendsClient({ initialFriends, initialRequests, inviteT
                 return (
                   <li
                     key={friend.id}
-                    className="rounded-[1.6rem] border border-[color:var(--color-border)] bg-white/72 p-4 shadow-[0_8px_24px_rgba(54,39,24,0.06)]"
+                    className="rounded-[var(--radius-lg)] border border-[color:var(--color-border)] bg-white/72 p-4 shadow-[0_8px_24px_rgba(54,39,24,0.06)]"
                   >
                     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                       <div className="flex items-center gap-3">
@@ -421,7 +421,7 @@ export default function FriendsClient({ initialFriends, initialRequests, inviteT
                         {isLoadingCommon ? <p className="text-sm text-muted-foreground">Chargement…</p> : null}
 
                         {!isLoadingCommon && commons.length === 0 ? (
-                          <div className="empty-state rounded-[1.35rem] border border-dashed border-[color:var(--color-border)] bg-[rgba(255,255,255,0.65)]">
+                          <div className="empty-state rounded-[var(--radius-md)] border border-dashed border-[color:var(--color-border)] bg-[rgba(255,255,255,0.65)]">
                             <strong>Aucune œuvre commune pour le moment.</strong>
                           </div>
                         ) : null}

--- a/app/src/features/reactions/ui/LikesLibrary.tsx
+++ b/app/src/features/reactions/ui/LikesLibrary.tsx
@@ -210,7 +210,7 @@ function LikesSection({ title, description, emptyLabel, items, tone, onAct }: Li
       </div>
 
       {items.length === 0 ? (
-        <div className="empty-state rounded-[1.5rem] border border-dashed border-[color:var(--color-border)] bg-white/50">
+        <div className="empty-state rounded-[var(--radius-lg)] border border-dashed border-[color:var(--color-border)] bg-white/50">
           <strong>{emptyLabel}</strong>
         </div>
       ) : (

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -15,11 +15,11 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
 
   return (
     <article
-      className="flex h-full w-full flex-col overflow-hidden rounded-[1.85rem] bg-[color:var(--color-surface-strong)] outline-none"
+      className="flex h-full w-full flex-col overflow-hidden rounded-[var(--radius-xl)] bg-[color:var(--color-surface-strong)] outline-none"
       tabIndex={-1}
       aria-describedby={`work-${work.id}-title`}
     >
-      <div className="relative min-h-[14rem] flex-1 overflow-hidden rounded-[1.85rem] bg-muted">
+      <div className="relative min-h-[14rem] flex-1 overflow-hidden rounded-[var(--radius-xl)] bg-muted">
         {work.imageUrl ? (
           <Image
             src={work.imageUrl}

--- a/app/src/features/works/ui/SwipeDeck.tsx
+++ b/app/src/features/works/ui/SwipeDeck.tsx
@@ -279,7 +279,7 @@ export default function SwipeDeck({ items, totalCount }: Props) {
           <div
             key={item.id}
             aria-hidden
-            className="pointer-events-none absolute inset-x-[4%] top-6 bottom-16 rounded-[2rem] border border-[color:var(--color-border)] bg-white/55 shadow-[0_22px_48px_rgba(54,39,24,0.10)]"
+            className="pointer-events-none absolute inset-x-[4%] top-6 bottom-16 rounded-[var(--radius-2xl)] border border-[color:var(--color-border)] bg-white/55 shadow-[0_22px_48px_rgba(54,39,24,0.10)]"
             style={{
               transform: `translateY(${(previewIndex + 1) * 14}px) scale(${1 - (previewIndex + 1) * 0.03})`,
               opacity: 0.9 - previewIndex * 0.18,
@@ -298,7 +298,7 @@ export default function SwipeDeck({ items, totalCount }: Props) {
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
           style={{ transform, pointerEvents: pending ? 'none' : 'auto' }}
-          className="relative z-10 h-full w-full max-w-xl cursor-grab touch-none rounded-[2rem] border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-2 shadow-[var(--shadow-lg)] will-change-transform"
+          className="relative z-10 h-full w-full max-w-xl cursor-grab touch-none rounded-[var(--radius-2xl)] border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-2 shadow-[var(--shadow-lg)] will-change-transform"
         >
           <CardWork work={current} />
           <div className="pointer-events-none absolute inset-x-6 top-6 flex items-start justify-between">

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -102,7 +102,7 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
 
 function SummaryRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-start justify-between gap-3 rounded-[1rem] border border-[color:var(--color-border)] bg-white/60 px-3 py-2">
+    <div className="flex items-start justify-between gap-3 rounded-[var(--radius-panel)] border border-[color:var(--color-border)] bg-white/60 px-3 py-2">
       <span className="text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">{label}</span>
       <span className="text-right font-medium leading-6">{value}</span>
     </div>


### PR DESCRIPTION
Cosmétique : introduit une échelle de rayons (`--radius-md/lg/xl/2xl` aux côtés de `--radius-control/panel`) et remplace **toutes** les valeurs `rounded-[…]` en dur (10 valeurs ad-hoc de 1 à 2rem dans 7 fichiers) par des `var(--radius-*)`. Plus aucun rayon littéral dans `src`.

Aucune logique touchée. lint/typecheck verts, 85/85 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)