### PR TITLE
feat: arrondissement (théâtre) + nationalité/année (cinéma) sur la carte

### DIFF
--- a/app/prisma/migrations/20260608140000_add_work_locality_meta/migration.sql
+++ b/app/prisma/migrations/20260608140000_add_work_locality_meta/migration.sql
@@ -1,0 +1,7 @@
+-- Métadonnées additionnelles sur les œuvres (additif, non destructif) :
+--  - arrondissement : ville/arrondissement (théâtre), ex. "Paris 10e"
+--  - country        : nationalité (cinéma), ex. "États-Unis"
+--  - year           : année de production (cinéma)
+ALTER TABLE "Work" ADD COLUMN "arrondissement" TEXT;
+ALTER TABLE "Work" ADD COLUMN "country" TEXT;
+ALTER TABLE "Work" ADD COLUMN "year" INTEGER;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -85,6 +85,9 @@ model Work {
   imageUrl  String?
   director  String?
   cast      String[]
+  arrondissement String?  // ville/arrondissement (théâtre) : "Paris 10e"
+  country   String?        // nationalité (cinéma) : "États-Unis"
+  year      Int?           // année de production (cinéma)
   sourceUrl String    @unique
 
   // ✅ Réactions (remplace l'ancien Work.likes)

--- a/app/scripts/backfill-meta.ts
+++ b/app/scripts/backfill-meta.ts
@@ -1,0 +1,82 @@
+// Backfill one-off : remplit Work.arrondissement (théâtre) et Work.country/year
+// (cinéma) pour les œuvres existantes. Les nouveaux scrapes les capturent
+// nativement. Récupère la fiche Offi, délègue l'extraction au CLI Python
+// (même logique que le scraper, zéro duplication), puis met à jour via Prisma.
+//
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/backfill-meta.ts [limit]
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { prisma } from '@/server/db'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const scraperDir = path.resolve(here, '../../scraper')
+const PY = path.join(scraperDir, '.venv/bin/python')
+const CLI = path.join(scraperDir, 'extract_credits_cli.py')
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+
+const limit = Number(process.argv[2] ?? 40)
+
+type Extracted = { arrondissement: string | null; country: string | null; year: number | null }
+
+function extract(html: string): Extracted {
+  const res = spawnSync(PY, [CLI], {
+    input: html,
+    encoding: 'utf-8',
+    cwd: scraperDir,
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 10_000,
+    killSignal: 'SIGKILL',
+  })
+  if (res.status !== 0 || !res.stdout) return { arrondissement: null, country: null, year: null }
+  try {
+    const parsed = JSON.parse(res.stdout)
+    return { arrondissement: parsed.arrondissement ?? null, country: parsed.country ?? null, year: parsed.year ?? null }
+  } catch {
+    return { arrondissement: null, country: null, year: null }
+  }
+}
+
+async function main() {
+  // Œuvres encore sans aucune des nouvelles métadonnées.
+  const works = await prisma.work.findMany({
+    where: { arrondissement: null, country: null, year: null },
+    select: { id: true, sourceUrl: true, section: true },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  let updated = 0
+  for (const work of works) {
+    try {
+      const response = await fetch(work.sourceUrl, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(15_000) })
+      if (!response.ok) continue
+      const { arrondissement, country, year } = extract(await response.text())
+
+      // On ne renseigne que ce qui a du sens par segment.
+      const data: { arrondissement?: string; country?: string; year?: number } = {}
+      if (work.section === 'theatre' && arrondissement) data.arrondissement = arrondissement
+      if (work.section === 'cinema') {
+        if (country) data.country = country
+        if (year) data.year = year
+      }
+
+      if (Object.keys(data).length > 0) {
+        await prisma.work.update({ where: { id: work.id }, data })
+        updated += 1
+      }
+      await new Promise((resolve) => setTimeout(resolve, 400)) // throttle poli envers offi.fr
+    } catch {
+      // on saute les fiches en erreur, sans interrompre le backfill
+    }
+  }
+
+  console.log(JSON.stringify({ scanned: works.length, updated }))
+}
+
+main()
+  .catch((error) => {
+    console.error('[backfill-meta]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/app/src/features/offi-import/mappers.ts
+++ b/app/src/features/offi-import/mappers.ts
@@ -25,6 +25,9 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
     imageUrl: record.image ?? null,
     director: record.director ?? null,
     cast: record.cast ?? [],
+    arrondissement: record.arrondissement ?? null,
+    country: record.country ?? null,
+    year: record.year ?? null,
     sourceUrl: record.url,
   }
 
@@ -45,6 +48,9 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
   if (record.image != null) update.imageUrl = record.image
   if (record.director != null) update.director = record.director
   if (record.cast.length > 0) update.cast = record.cast
+  if (record.arrondissement != null) update.arrondissement = record.arrondissement
+  if (record.country != null) update.country = record.country
+  if (record.year != null) update.year = record.year
 
   return { create, update }
 }

--- a/app/src/features/offi-import/schemas.ts
+++ b/app/src/features/offi-import/schemas.ts
@@ -48,6 +48,11 @@ const nullableInt = z.preprocess(
   z.number().int().positive().max(600).nullable(),
 )
 
+const nullableYear = z.preprocess(
+  (value) => (value === undefined || value === null || value === '' ? null : value),
+  z.number().int().min(1880).max(2100).nullable(),
+)
+
 const nullableMoney = z.preprocess(
   (value) => (value === undefined || value === null || value === '' ? null : value),
   z.number().nonnegative().max(500).nullable(),
@@ -62,6 +67,8 @@ export const offiWorkSchema = z
     venue: nullableString(160),
     address: nullableString(240),
     arrondissement: nullableString(80),
+    country: nullableString(80),
+    year: nullableYear,
     date_start: nullableIsoDate,
     date_end: nullableIsoDate,
     duration_min: nullableInt,

--- a/app/src/features/works/dto.ts
+++ b/app/src/features/works/dto.ts
@@ -17,6 +17,9 @@ export const workCardSelect = {
   priceMax: true,
   director: true,
   cast: true,
+  arrondissement: true,
+  country: true,
+  year: true,
   sourceUrl: true,
 } satisfies Prisma.WorkSelect
 
@@ -38,6 +41,9 @@ export type WorkCardDto = {
   priceMax: number | null
   director: string | null
   cast: string[]
+  arrondissement: string | null
+  country: string | null
+  year: number | null
   sourceUrl: string | null
 }
 
@@ -58,6 +64,9 @@ export function mapWorkToCardDto(work: WorkCardRecord): WorkCardDto {
     priceMax: work.priceMax,
     director: work.director,
     cast: work.cast,
+    arrondissement: work.arrondissement,
+    country: work.country,
+    year: work.year,
     sourceUrl: work.sourceUrl,
   }
 }

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -12,6 +12,11 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
   const sectionLabel = work.section === 'cinema' ? 'Cinéma' : 'Théâtre'
   const directorLabel = work.section === 'cinema' ? 'De' : 'Mise en scène'
   const hasFacts = genres.length > 0 || Boolean(durationLabel) || Boolean(priceLabel)
+  // Ligne d'eyebrow : lieu (théâtre, avec arrondissement) ou nationalité·année (cinéma).
+  const venueLine = [work.venue, work.section === 'theatre' ? work.arrondissement : null]
+    .filter(Boolean)
+    .join(' · ')
+  const cinemaMeta = work.section === 'cinema' ? [work.country, work.year].filter(Boolean).join(' · ') : ''
 
   return (
     <article
@@ -42,9 +47,14 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
 
       <div className="flex flex-col gap-3 p-5">
         <div className="space-y-1.5">
-          {work.venue ? (
+          {venueLine ? (
             <p className="text-[0.78rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
-              📍 {work.venue}
+              📍 {venueLine}
+            </p>
+          ) : null}
+          {cinemaMeta ? (
+            <p className="text-[0.78rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
+              {cinemaMeta}
             </p>
           ) : null}
           <h2

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -22,6 +22,10 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
   const director = work?.director?.trim()
   const castNames = work?.cast?.slice(0, 5) ?? []
   const directorLabel = work?.section === 'cinema' ? 'De' : 'Mise en scène'
+  const venueLine = work
+    ? [work.venue, work.section === 'theatre' ? work.arrondissement : null].filter(Boolean).join(' · ')
+    : ''
+  const cinemaMeta = work?.section === 'cinema' ? [work.country, work.year].filter(Boolean).join(' · ') : ''
 
   return (
     <SurfaceCard className={cn('flex h-full flex-col overflow-hidden p-0', className)} tone="muted">
@@ -54,7 +58,8 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
       <div className="flex flex-1 flex-col gap-4 p-4">
         <div className="space-y-2">
           <h3 className="line-clamp-2 text-lg font-semibold tracking-[-0.03em] text-[color:var(--color-text)]">{title}</h3>
-          {work?.venue ? <p className="text-sm font-medium text-muted-foreground">{work.venue}</p> : null}
+          {venueLine ? <p className="text-sm font-medium text-muted-foreground">{venueLine}</p> : null}
+          {cinemaMeta ? <p className="text-sm font-medium text-muted-foreground">{cinemaMeta}</p> : null}
           {director || castNames.length > 0 ? (
             <div className="space-y-0.5 text-sm leading-6">
               {director ? (

--- a/app/tests/card-work.test.tsx
+++ b/app/tests/card-work.test.tsx
@@ -25,6 +25,9 @@ const base: WorkCardDto = {
   priceMax: null,
   director: 'Kelly Reichardt',
   cast: ['Michelle Williams', 'Will Oldham'],
+  arrondissement: null,
+  country: 'États-Unis',
+  year: 2008,
   sourceUrl: 'https://www.offi.fr/x',
 }
 
@@ -62,5 +65,26 @@ describe('CardWork', () => {
     render(<CardWork work={{ ...base, durationMin: null, priceMin: null, priceMax: null, category: null }} />)
     expect(screen.queryByText(/Tarifs non communiqués/)).not.toBeInTheDocument()
     expect(screen.queryByText(/Dates à venir/)).not.toBeInTheDocument()
+  })
+
+  it('cinéma : affiche la nationalité et l’année', () => {
+    render(<CardWork work={{ ...base, venue: null }} />)
+    expect(screen.getByText('États-Unis · 2008')).toBeInTheDocument()
+  })
+
+  it('théâtre : affiche le lieu avec l’arrondissement', () => {
+    render(
+      <CardWork
+        work={{
+          ...base,
+          section: 'theatre',
+          venue: 'Théâtre de la Huchette',
+          arrondissement: 'Paris 5e',
+          country: null,
+          year: null,
+        }}
+      />,
+    )
+    expect(screen.getByText(/Théâtre de la Huchette · Paris 5e/)).toBeInTheDocument()
   })
 })

--- a/app/tests/offi.test.ts
+++ b/app/tests/offi.test.ts
@@ -82,6 +82,58 @@ describe('Offi ingestion helpers', () => {
     expect(record.section).toBe('cinema')
   })
 
+  it('parse et mappe arrondissement (théâtre) + nationalité/année (cinéma)', () => {
+    const theatre = parseOffiJsonLine(
+      JSON.stringify({
+        url: 'https://www.offi.fr/theatre/theatre-de-la-huchette-2490/crime-et-chatiment-105182.html',
+        title: 'Crime et Châtiment',
+        section: 'theatre',
+        arrondissement: 'Paris 5e',
+        description: 'Adaptation du roman.',
+        date_start: '2026-03-14',
+      }),
+      1,
+    )
+    expect(theatre.arrondissement).toBe('Paris 5e')
+    expect(buildWorkUpsert(theatre).create.arrondissement).toBe('Paris 5e')
+
+    const cinema = parseOffiJsonLine(
+      JSON.stringify({
+        url: 'https://www.offi.fr/cinema/evenement/voyage-au-bout-de-l-enfer-104603.html',
+        title: 'Voyage au bout de l’enfer',
+        section: 'cinema',
+        country: 'États-Unis',
+        year: 1978,
+        description: 'Un drame de guerre.',
+        date_start: '2026-03-12',
+      }),
+      1,
+    )
+    expect(cinema.country).toBe('États-Unis')
+    expect(cinema.year).toBe(1978)
+    const { create, update } = buildWorkUpsert(cinema)
+    expect(create.country).toBe('États-Unis')
+    expect(create.year).toBe(1978)
+    expect(update).toHaveProperty('country', 'États-Unis')
+    expect(update).toHaveProperty('year', 1978)
+  })
+
+  it('rejette une année hors plage', () => {
+    expect(() =>
+      parseOffiJsonLine(
+        JSON.stringify({
+          url: 'https://www.offi.fr/cinema/evenement/x-1.html',
+          title: 'X',
+          section: 'cinema',
+          year: 1700,
+          description: 'desc',
+          date_start: '2026-03-12',
+        }),
+        7,
+      ),
+    ).toThrow(/Line 7/)
+  })
+
   it('rejects invalid records with useful line numbers', () => {
     expect(() =>
       parseOffiJsonLine(

--- a/scraper/extract_credits_cli.py
+++ b/scraper/extract_credits_cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-"""Lit le HTML d'une fiche Offi sur stdin, imprime {"director","cast"} en JSON.
-Réutilise parsers.extract_credits (même logique que le scraper) — utilisé par le
-backfill one-off app/scripts/backfill-credits.ts."""
+"""Lit le HTML d'une fiche Offi sur stdin, imprime en JSON les champs extraits
+({"director","cast","arrondissement","country","year"}). Réutilise les parsers
+du scraper (même logique) — utilisé par les backfills one-off de app/scripts/."""
 import sys
 import json
 
@@ -14,9 +14,22 @@ except ImportError:  # exécuté depuis le dossier scraper/
 
 
 def main() -> None:
-    html = sys.stdin.read()
-    director, cast = parsers.extract_credits(BeautifulSoup(html, "html.parser"))
-    print(json.dumps({"director": director, "cast": cast}, ensure_ascii=False))
+    soup = BeautifulSoup(sys.stdin.read(), "html.parser")
+    director, cast = parsers.extract_credits(soup)
+    country, year = parsers.extract_cinema_meta(soup)
+    arrondissement = parsers.extract_arrondissement(soup)
+    print(
+        json.dumps(
+            {
+                "director": director,
+                "cast": cast,
+                "arrondissement": arrondissement,
+                "country": country,
+                "year": year,
+            },
+            ensure_ascii=False,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/scraper/offi_scraper.py
+++ b/scraper/offi_scraper.py
@@ -172,6 +172,9 @@ class Show:
     description: Optional[str] = None
     director: Optional[str] = None
     cast: list[str] = field(default_factory=list)
+    arrondissement: Optional[str] = None  # ville/arrondissement (théâtre) : "Paris 10e"
+    country: Optional[str] = None          # nationalité (cinéma) : "États-Unis"
+    year: Optional[int] = None             # année de production (cinéma)
     crawled_at: Optional[str] = None
 
     def is_empty(self) -> bool:
@@ -373,6 +376,9 @@ class OffiScraper:
             description=payload.get("description"),
             director=payload.get("director"),
             cast=payload.get("cast") or [],
+            arrondissement=payload.get("arrondissement"),
+            country=payload.get("country"),
+            year=payload.get("year"),
             crawled_at=payload.get("crawled_at"),
         )
 
@@ -763,6 +769,12 @@ class OffiScraper:
         show.address = self._clean_text(show.address)
         show.image = self._clean_text(show.image)
         show.description = self._clean_text(show.description)
+        show.arrondissement = self._clean_text(show.arrondissement)
+        show.country = self._clean_text(show.country)
+
+        if show.year is not None and not (1880 <= show.year <= 2100):
+            logging.warning("Année de production invalide pour %s: %s", show.url, show.year)
+            show.year = None
 
         if not show.title:
             logging.warning("Show ignoré sans titre: %s", show.url)
@@ -842,6 +854,9 @@ class OffiScraper:
         if not show.address:
             show.address = self._extract_address(soup)
 
+        if not show.arrondissement:
+            show.arrondissement = parsers.extract_arrondissement(soup)
+
         if not (show.date_start and show.date_end):
             date_bins: List[str] = []
             for sel in [
@@ -907,6 +922,13 @@ class OffiScraper:
 
         if not show.duration_min:
             show.duration_min = self._extract_cinema_duration(soup)
+
+        if not (show.country and show.year):
+            country, year = parsers.extract_cinema_meta(soup)
+            if not show.country and country:
+                show.country = country
+            if not show.year and year:
+                show.year = year
 
         return show
 

--- a/scraper/parsers.py
+++ b/scraper/parsers.py
@@ -154,3 +154,65 @@ def extract_credits(soup) -> tuple[Optional[str], list[str]]:
 
     cast = [c for c in cast if c and c != director and 2 <= len(c) <= 40][:8]
     return director, cast
+
+
+# --- Métadonnées cinéma : nationalité + année de production ---------------------
+# La « fiche technique » ciné expose "Nationalité : X" et "Année de production : YYYY".
+_NATIONALITY_RE = re.compile(
+    r"Nationalit[ée]\s*:?\s*([A-Za-zÀ-ÿ'’\- ,]{2,40}?)\s*"
+    r"(?:Dur[ée]e|Langue|Ann[ée]e|Genre|Date|Distributeur|Num[ée]ro|Visa|R[ée]alisation|Sortie|\||$)",
+    re.IGNORECASE,
+)
+_PROD_YEAR_RE = re.compile(r"Ann[ée]e\s+de\s+production\s*:?\s*(\d{4})", re.IGNORECASE)
+
+
+def extract_cinema_meta(soup) -> tuple[Optional[str], Optional[int]]:
+    """Retourne (country, year) depuis une fiche ciné (BeautifulSoup)."""
+    text = soup.get_text(" ", strip=True)
+
+    country: Optional[str] = None
+    m = _NATIONALITY_RE.search(text)
+    if m:
+        candidate = _clean_credit(m.group(1))
+        if candidate:
+            country = candidate
+
+    year: Optional[int] = None
+    y = _PROD_YEAR_RE.search(text)
+    if y:
+        value = int(y.group(1))
+        if 1880 <= value <= 2100:
+            year = value
+
+    return country, year
+
+
+# --- Arrondissement / ville (théâtre) ------------------------------------------
+# Microdata `addressLocality` ("Paris 5e", "Boulogne-Billancourt"). Fallback :
+# dériver depuis le code postal parisien (75001..75020 → "Paris 1er..20e").
+def arrondissement_from_postal(code: Optional[str]) -> Optional[str]:
+    code = (code or "").strip()
+    m = re.match(r"^75(\d{3})$", code)
+    if not m:
+        return None
+    n = int(m.group(1))
+    if not 1 <= n <= 20:
+        return None
+    suffix = "er" if n == 1 else "e"
+    return f"Paris {n}{suffix}"
+
+
+def extract_arrondissement(soup) -> Optional[str]:
+    """Retourne la ville/arrondissement ("Paris 10e") depuis une fiche (BeautifulSoup)."""
+    el = soup.select_one('[itemprop="addressLocality"]')
+    if el:
+        value = _clean_credit(el.get("content") or el.get_text(" ", strip=True))
+        if value:
+            return value
+
+    pc = soup.select_one('[itemprop="postalCode"]')
+    if pc:
+        code = (pc.get("content") or pc.get_text(" ", strip=True) or "").strip()
+        return arrondissement_from_postal(code)
+
+    return None

--- a/scraper/tests/test_parsers.py
+++ b/scraper/tests/test_parsers.py
@@ -90,5 +90,50 @@ class ParsersTests(unittest.TestCase):
         self.assertFalse(parsers.is_valid_iso_date(None))
 
 
+class ExtractCinemaMetaTests(unittest.TestCase):
+    def test_nationality_and_year(self):
+        html = (
+            "<div>Genre : Horreur Nationalité : France Durée : 1h22 "
+            "Année de production : 1959 Date de sortie</div>"
+        )
+        country, year = parsers.extract_cinema_meta(_soup(html))
+        self.assertEqual(country, "France")
+        self.assertEqual(year, 1959)
+
+    def test_multiword_nationality_stops_at_next_label(self):
+        html = "<div>Nationalité : Etats-Unis Langue : anglais Année de production : 1978</div>"
+        country, year = parsers.extract_cinema_meta(_soup(html))
+        self.assertEqual(country, "Etats-Unis")
+        self.assertEqual(year, 1978)
+
+    def test_missing_fields(self):
+        country, year = parsers.extract_cinema_meta(_soup("<div>Aucune fiche technique</div>"))
+        self.assertIsNone(country)
+        self.assertIsNone(year)
+
+    def test_year_out_of_range_ignored(self):
+        country, year = parsers.extract_cinema_meta(_soup("<div>Année de production : 1700</div>"))
+        self.assertIsNone(year)
+
+
+class ExtractArrondissementTests(unittest.TestCase):
+    def test_from_address_locality(self):
+        html = '<span itemprop="addressLocality">Paris 5e</span>'
+        self.assertEqual(parsers.extract_arrondissement(_soup(html)), "Paris 5e")
+
+    def test_fallback_from_postal_code(self):
+        html = '<span itemprop="postalCode">75010</span>'
+        self.assertEqual(parsers.extract_arrondissement(_soup(html)), "Paris 10e")
+
+    def test_postal_code_first_arrondissement(self):
+        self.assertEqual(parsers.arrondissement_from_postal("75001"), "Paris 1er")
+
+    def test_non_paris_postal_code(self):
+        self.assertIsNone(parsers.arrondissement_from_postal("92100"))
+
+    def test_missing(self):
+        self.assertIsNone(parsers.extract_arrondissement(_soup("<div>rien</div>")))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Exploite des données offi.fr jusqu ici ignorées, repérées lors de l exploration du scraper.

## Affichage
- **Théâtre** : arrondissement/ville (« Paris 10e ») accolé au lieu — depuis la microdata `addressLocality` (fallback : code postal parisien).
- **Cinéma** : nationalité + année (« États-Unis · 1978 ») — depuis la « fiche technique ».

## Chaîne complète
- `scraper/parsers.py` : `extract_cinema_meta()`, `extract_arrondissement()` (+ `arrondissement_from_postal`). Fonctions **pures, unitestées** (9 nouveaux tests, sanity-check sur vraies fiches OK).
- `Show` : champs `arrondissement`/`country`/`year` + extraction dans les pages détail ciné/théâtre.
- `extract_credits_cli.py` renvoie aussi ces champs (réutilisé par les backfills).
- `offi-import` : `schemas` (`country`/`year` ; `arrondissement` était déjà déclaré mais jamais câblé) + `mappers` (création **et** mise à jour).
- `dto` + `CardWork` + `WorkSummaryCard` : ligne eyebrow lieu·arrondissement / nationalité·année.
- Migration additive `20260608140000_add_work_locality_meta` (**appliquée sur Neon**).
- `scripts/backfill-meta.ts` pour remplir l existant.

## Notes
- **Image HD** (autre piste retenue) : déjà optimale — toutes les images en base sont en 1000px (`og:image`), donc **aucun changement nécessaire** (constat empirique).
- **Note/avis** : non retenue par le demandeur pour l instant (dispo si besoin plus tard).

lint/typecheck verts ; **89 tests app + 32 tests scraper** verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)