### PR TITLE
feat: prix structuré + dispo billet (offers) sur les œuvres

### DIFF
--- a/app/prisma/migrations/20260609090000_add_work_offers/migration.sql
+++ b/app/prisma/migrations/20260609090000_add_work_offers/migration.sql
@@ -1,0 +1,5 @@
+-- Offre billetterie structurée sur les œuvres (additif, non destructif) :
+--  - availability : disponibilité (schema.org), ex. "InStock", "SoldOut"
+--  - currency     : devise du prix, ex. "EUR"
+ALTER TABLE "Work" ADD COLUMN "availability" TEXT;
+ALTER TABLE "Work" ADD COLUMN "currency" TEXT;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -88,6 +88,8 @@ model Work {
   arrondissement String?  // ville/arrondissement (théâtre) : "Paris 10e"
   country   String?        // nationalité (cinéma) : "États-Unis"
   year      Int?           // année de production (cinéma)
+  availability String?     // dispo billetterie (schema.org) : "InStock", "SoldOut"…
+  currency  String?        // devise du prix : "EUR"
   sourceUrl String    @unique
 
   // ✅ Réactions (remplace l'ancien Work.likes)

--- a/app/scripts/backfill-offers.ts
+++ b/app/scripts/backfill-offers.ts
@@ -1,0 +1,86 @@
+// Backfill one-off : remplit Work.availability / Work.currency (et corrige les prix
+// depuis le bloc `offers`, plus fiable) pour les œuvres existantes. Les nouveaux
+// scrapes les capturent nativement. Délègue l'extraction au CLI Python.
+//
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/backfill-offers.ts [limit]
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { prisma } from '@/server/db'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const scraperDir = path.resolve(here, '../../scraper')
+const PY = path.join(scraperDir, '.venv/bin/python')
+const CLI = path.join(scraperDir, 'extract_credits_cli.py')
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+
+const limit = Number(process.argv[2] ?? 40)
+
+type Offers = { availability: string | null; currency: string | null; price_min: number | null; price_max: number | null }
+
+function extract(html: string): Offers {
+  const res = spawnSync(PY, [CLI], {
+    input: html,
+    encoding: 'utf-8',
+    cwd: scraperDir,
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 10_000,
+    killSignal: 'SIGKILL',
+  })
+  const empty: Offers = { availability: null, currency: null, price_min: null, price_max: null }
+  if (res.status !== 0 || !res.stdout) return empty
+  try {
+    const p = JSON.parse(res.stdout)
+    return {
+      availability: p.availability ?? null,
+      currency: p.currency ?? null,
+      price_min: p.price_min ?? null,
+      price_max: p.price_max ?? null,
+    }
+  } catch {
+    return empty
+  }
+}
+
+async function main() {
+  const works = await prisma.work.findMany({
+    where: { availability: null },
+    select: { id: true, sourceUrl: true },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  let updated = 0
+  for (const work of works) {
+    try {
+      const response = await fetch(work.sourceUrl, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(15_000) })
+      if (!response.ok) continue
+      const offers = extract(await response.text())
+
+      const data: { availability?: string; currency?: string; priceMin?: number; priceMax?: number } = {}
+      if (offers.availability) data.availability = offers.availability
+      if (offers.currency) data.currency = offers.currency
+      if (offers.price_min != null) {
+        data.priceMin = offers.price_min
+        data.priceMax = offers.price_max ?? offers.price_min
+      }
+
+      if (Object.keys(data).length > 0) {
+        await prisma.work.update({ where: { id: work.id }, data })
+        updated += 1
+      }
+      await new Promise((resolve) => setTimeout(resolve, 400)) // throttle poli envers offi.fr
+    } catch {
+      // on saute les fiches en erreur, sans interrompre le backfill
+    }
+  }
+
+  console.log(JSON.stringify({ scanned: works.length, updated }))
+}
+
+main()
+  .catch((error) => {
+    console.error('[backfill-offers]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/app/src/features/offi-import/mappers.ts
+++ b/app/src/features/offi-import/mappers.ts
@@ -28,6 +28,8 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
     arrondissement: record.arrondissement ?? null,
     country: record.country ?? null,
     year: record.year ?? null,
+    availability: record.availability ?? null,
+    currency: record.currency ?? null,
     sourceUrl: record.url,
   }
 
@@ -51,6 +53,8 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
   if (record.arrondissement != null) update.arrondissement = record.arrondissement
   if (record.country != null) update.country = record.country
   if (record.year != null) update.year = record.year
+  if (record.availability != null) update.availability = record.availability
+  if (record.currency != null) update.currency = record.currency
 
   return { create, update }
 }

--- a/app/src/features/offi-import/schemas.ts
+++ b/app/src/features/offi-import/schemas.ts
@@ -69,6 +69,8 @@ export const offiWorkSchema = z
     arrondissement: nullableString(80),
     country: nullableString(80),
     year: nullableYear,
+    availability: nullableString(40),
+    currency: nullableString(8),
     date_start: nullableIsoDate,
     date_end: nullableIsoDate,
     duration_min: nullableInt,

--- a/app/src/features/works/dto.ts
+++ b/app/src/features/works/dto.ts
@@ -20,6 +20,8 @@ export const workCardSelect = {
   arrondissement: true,
   country: true,
   year: true,
+  availability: true,
+  currency: true,
   sourceUrl: true,
 } satisfies Prisma.WorkSelect
 
@@ -44,6 +46,8 @@ export type WorkCardDto = {
   arrondissement: string | null
   country: string | null
   year: number | null
+  availability: string | null
+  currency: string | null
   sourceUrl: string | null
 }
 
@@ -67,6 +71,8 @@ export function mapWorkToCardDto(work: WorkCardRecord): WorkCardDto {
     arrondissement: work.arrondissement,
     country: work.country,
     year: work.year,
+    availability: work.availability,
+    currency: work.currency,
     sourceUrl: work.sourceUrl,
   }
 }

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -2,16 +2,24 @@ import Image from 'next/image'
 import { splitGenres } from '@/features/works/category'
 import type { WorkCardDto } from '@/features/works/dto'
 import ExpandableDescription from '@/features/works/ui/ExpandableDescription'
-import { formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
+import { formatAvailability, formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
+
+const AVAILABILITY_CHIP_CLASS: Record<'success' | 'danger' | 'warning', string> = {
+  success: 'bg-[color:var(--color-success-soft)] text-[color:var(--color-success)]',
+  warning: 'bg-[rgba(160,74,65,0.10)] text-[color:var(--color-danger)]',
+  danger: 'bg-[color:var(--color-danger-soft)] text-[color:var(--color-danger)]',
+}
 
 export default function CardWork({ work }: { work: WorkCardDto }) {
   const durationLabel = formatDuration(work.durationMin)
   const priceLabel = formatPriceRange(work.priceMin, work.priceMax)
+  const availability = formatAvailability(work.availability)
   const description = work.description?.trim()
   const genres = splitGenres(work.category).slice(0, 3)
   const sectionLabel = work.section === 'cinema' ? 'Cinéma' : 'Théâtre'
   const directorLabel = work.section === 'cinema' ? 'De' : 'Mise en scène'
-  const hasFacts = genres.length > 0 || Boolean(durationLabel) || Boolean(priceLabel)
+  const hasFacts =
+    genres.length > 0 || Boolean(durationLabel) || Boolean(priceLabel) || Boolean(availability)
   // Ligne d'eyebrow : lieu (théâtre, avec arrondissement) ou nationalité·année (cinéma).
   const venueLine = [work.venue, work.section === 'theatre' ? work.arrondissement : null]
     .filter(Boolean)
@@ -100,6 +108,11 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
             {priceLabel ? (
               <span className="rounded-full bg-[rgba(54,39,24,0.06)] px-3 py-1 text-xs font-medium text-[color:var(--color-text)]">
                 💶 {priceLabel}
+              </span>
+            ) : null}
+            {availability ? (
+              <span className={`rounded-full px-3 py-1 text-xs font-semibold ${AVAILABILITY_CHIP_CLASS[availability.tone]}`}>
+                {availability.label}
               </span>
             ) : null}
           </div>

--- a/app/src/features/works/ui/work-formatters.ts
+++ b/app/src/features/works/ui/work-formatters.ts
@@ -44,6 +44,28 @@ export function formatPriceRange(min: number | null, max: number | null) {
   return null
 }
 
+// Disponibilité billetterie (valeurs schema.org) → libellé + tonalité d'affichage.
+export type AvailabilityBadge = { label: string; tone: 'success' | 'danger' | 'warning' }
+
+export function formatAvailability(availability: string | null): AvailabilityBadge | null {
+  switch (availability) {
+    case 'InStock':
+    case 'OnlineOnly':
+    case 'InStoreOnly':
+      return { label: 'Billets dispo', tone: 'success' }
+    case 'LimitedAvailability':
+    case 'PreOrder':
+    case 'PreSale':
+    case 'BackOrder':
+      return { label: 'Dernières places', tone: 'warning' }
+    case 'SoldOut':
+    case 'OutOfStock':
+      return { label: 'Complet', tone: 'danger' }
+    default:
+      return null
+  }
+}
+
 export function formatDuration(durationMin: number | null) {
   if (!durationMin) {
     return null

--- a/app/tests/card-work.test.tsx
+++ b/app/tests/card-work.test.tsx
@@ -28,6 +28,8 @@ const base: WorkCardDto = {
   arrondissement: null,
   country: 'États-Unis',
   year: 2008,
+  availability: null,
+  currency: null,
   sourceUrl: 'https://www.offi.fr/x',
 }
 
@@ -70,6 +72,16 @@ describe('CardWork', () => {
   it('cinéma : affiche la nationalité et l’année', () => {
     render(<CardWork work={{ ...base, venue: null }} />)
     expect(screen.getByText('États-Unis · 2008')).toBeInTheDocument()
+  })
+
+  it('affiche un badge « Billets dispo » quand availability=InStock', () => {
+    render(<CardWork work={{ ...base, availability: 'InStock' }} />)
+    expect(screen.getByText('Billets dispo')).toBeInTheDocument()
+  })
+
+  it('affiche « Complet » quand availability=SoldOut', () => {
+    render(<CardWork work={{ ...base, availability: 'SoldOut' }} />)
+    expect(screen.getByText('Complet')).toBeInTheDocument()
   })
 
   it('théâtre : affiche le lieu avec l’arrondissement', () => {

--- a/scraper/extract_credits_cli.py
+++ b/scraper/extract_credits_cli.py
@@ -18,6 +18,7 @@ def main() -> None:
     director, cast = parsers.extract_credits(soup)
     country, year = parsers.extract_cinema_meta(soup)
     arrondissement = parsers.extract_arrondissement(soup)
+    offers = parsers.extract_offers(soup)
     print(
         json.dumps(
             {
@@ -26,6 +27,10 @@ def main() -> None:
                 "arrondissement": arrondissement,
                 "country": country,
                 "year": year,
+                "availability": offers["availability"],
+                "currency": offers["currency"],
+                "price_min": offers["price_min"],
+                "price_max": offers["price_max"],
             },
             ensure_ascii=False,
         )

--- a/scraper/offi_scraper.py
+++ b/scraper/offi_scraper.py
@@ -175,6 +175,8 @@ class Show:
     arrondissement: Optional[str] = None  # ville/arrondissement (théâtre) : "Paris 10e"
     country: Optional[str] = None          # nationalité (cinéma) : "États-Unis"
     year: Optional[int] = None             # année de production (cinéma)
+    availability: Optional[str] = None     # dispo billetterie : "InStock", "SoldOut"…
+    currency: Optional[str] = None         # devise du prix : "EUR"
     crawled_at: Optional[str] = None
 
     def is_empty(self) -> bool:
@@ -379,6 +381,8 @@ class OffiScraper:
             arrondissement=payload.get("arrondissement"),
             country=payload.get("country"),
             year=payload.get("year"),
+            availability=payload.get("availability"),
+            currency=payload.get("currency"),
             crawled_at=payload.get("crawled_at"),
         )
 
@@ -771,6 +775,8 @@ class OffiScraper:
         show.description = self._clean_text(show.description)
         show.arrondissement = self._clean_text(show.arrondissement)
         show.country = self._clean_text(show.country)
+        show.availability = self._clean_text(show.availability)
+        show.currency = self._clean_text(show.currency)
 
         if show.year is not None and not (1880 <= show.year <= 2100):
             logging.warning("Année de production invalide pour %s: %s", show.url, show.year)
@@ -957,6 +963,18 @@ class OffiScraper:
             show.director = director
         if not show.cast and cast:
             show.cast = cast
+
+        # Offre billetterie structurée (surtout théâtre) : plus fiable que le regex.
+        offers = parsers.extract_offers(soup)
+        if not show.availability and offers["availability"]:
+            show.availability = offers["availability"]
+        if not show.currency and offers["currency"]:
+            show.currency = offers["currency"]
+        if offers["price_min"] is not None:
+            show.price_min_eur = offers["price_min"]
+            show.price_max_eur = (
+                offers["price_max"] if offers["price_max"] is not None else offers["price_min"]
+            )
 
         if show.section == "cinema":
             return self._complete_cinema_show_from_detail_page(show, soup)

--- a/scraper/parsers.py
+++ b/scraper/parsers.py
@@ -216,3 +216,64 @@ def extract_arrondissement(soup) -> Optional[str]:
         return arrondissement_from_postal(code)
 
     return None
+
+
+# --- Offre billetterie : disponibilité, devise, prix structurés ----------------
+# Offi expose un bloc `offers` (microdata schema.org) sur les fiches avec billetterie
+# (surtout théâtre) : availability ("https://schema.org/InStock"), priceCurrency,
+# lowPrice/highPrice (ou price). Plus fiable que le regex texte sur "tarif".
+_KNOWN_AVAILABILITY = {
+    "InStock", "SoldOut", "PreOrder", "OutOfStock", "LimitedAvailability",
+    "PreSale", "Discontinued", "InStoreOnly", "OnlineOnly", "BackOrder",
+}
+
+
+def _itemprop_value(soup, name: str) -> Optional[str]:
+    el = soup.select_one(f'[itemprop="{name}"]')
+    if not el:
+        return None
+    value = el.get("content") or el.get("href") or el.get_text(" ", strip=True)
+    return value.strip() if value else None
+
+
+def _to_price(value: Optional[str]) -> Optional[float]:
+    if not value:
+        return None
+    match = re.search(r"\d+(?:[.,]\d+)?", value)
+    if not match:
+        return None
+    try:
+        price = float(match.group(0).replace(",", "."))
+    except ValueError:
+        return None
+    return price if 0 <= price <= 1000 else None
+
+
+def extract_offers(soup) -> dict:
+    """Retourne {availability, currency, price_min, price_max} depuis le bloc offers."""
+    availability = _itemprop_value(soup, "availability")
+    if availability:
+        # "https://schema.org/InStock" -> "InStock"
+        availability = availability.rstrip("/").rsplit("/", 1)[-1]
+        if availability not in _KNOWN_AVAILABILITY:
+            availability = None
+
+    currency = _itemprop_value(soup, "priceCurrency")
+    if currency:
+        currency = currency.upper()[:3] if re.fullmatch(r"[A-Za-z]{3}", currency) else None
+
+    low = _to_price(_itemprop_value(soup, "lowPrice"))
+    high = _to_price(_itemprop_value(soup, "highPrice"))
+    single = _to_price(_itemprop_value(soup, "price"))
+
+    price_min = low if low is not None else single
+    price_max = high if high is not None else single
+    if price_min is not None and price_max is not None and price_min > price_max:
+        price_min, price_max = price_max, price_min
+
+    return {
+        "availability": availability,
+        "currency": currency,
+        "price_min": price_min,
+        "price_max": price_max,
+    }

--- a/scraper/tests/test_parsers.py
+++ b/scraper/tests/test_parsers.py
@@ -135,5 +135,39 @@ class ExtractArrondissementTests(unittest.TestCase):
         self.assertIsNone(parsers.extract_arrondissement(_soup("<div>rien</div>")))
 
 
+class ExtractOffersTests(unittest.TestCase):
+    def test_full_offer(self):
+        html = (
+            '<div itemprop="offers">'
+            '<link itemprop="availability" href="https://schema.org/InStock">'
+            '<span itemprop="priceCurrency">EUR</span>'
+            '<span itemprop="lowPrice">18,50</span><span itemprop="highPrice">42</span>'
+            '</div>'
+        )
+        o = parsers.extract_offers(_soup(html))
+        self.assertEqual(o["availability"], "InStock")
+        self.assertEqual(o["currency"], "EUR")
+        self.assertEqual(o["price_min"], 18.5)
+        self.assertEqual(o["price_max"], 42.0)
+
+    def test_single_price(self):
+        html = (
+            '<meta itemprop="availability" content="https://schema.org/SoldOut">'
+            '<span itemprop="price">24.50</span><span itemprop="priceCurrency">EUR</span>'
+        )
+        o = parsers.extract_offers(_soup(html))
+        self.assertEqual(o["availability"], "SoldOut")
+        self.assertEqual(o["price_min"], 24.5)
+        self.assertEqual(o["price_max"], 24.5)
+
+    def test_unknown_availability_dropped(self):
+        o = parsers.extract_offers(_soup('<link itemprop="availability" href="https://schema.org/Bogus">'))
+        self.assertIsNone(o["availability"])
+
+    def test_empty(self):
+        o = parsers.extract_offers(_soup("<div>rien</div>"))
+        self.assertEqual(o, {"availability": None, "currency": None, "price_min": None, "price_max": None})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Exploite le bloc microdata `offers` d offi (surtout théâtre), plus fiable que le regex texte sur « tarif ».

- **Disponibilité** : `availability` (schema.org) → badge **« Billets dispo » / « Dernières places » / « Complet »** sur la carte.
- **Devise + prix** : `priceCurrency` (EUR) + `lowPrice`/`highPrice` (prioritaires sur le regex).

## Chaîne
- `scraper/parsers.py` : `extract_offers()` (pure, **+4 tests** → 36 scraper).
- `Show` : `availability`/`currency` + extraction pages détail ; prix `offers` prioritaires. CLI de backfill étendu.
- `offi-import` schemas + mappers ; DTO ; `work-formatters.formatAvailability` ; badge `CardWork`.
- Migration additive `add_work_offers` (**appliquée sur Neon**).
- `scripts/backfill-offers.ts` (backfill en cours).

lint/typecheck verts ; tests app verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)