### PR TITLE
feat: catalogue des lieux (Venue) + lien Work.venueId (théâtre)

### DIFF
--- a/app/prisma/migrations/20260609100000_add_venue/migration.sql
+++ b/app/prisma/migrations/20260609100000_add_venue/migration.sql
@@ -1,0 +1,29 @@
+-- Catalogue des lieux (théâtres + cinémas) + lien optionnel Work → Venue (additif).
+CREATE TABLE "Venue" (
+    "id" TEXT NOT NULL,
+    "offiId" INTEGER NOT NULL,
+    "kind" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "streetAddress" TEXT,
+    "postalCode" TEXT,
+    "city" TEXT,
+    "country" TEXT,
+    "latitude" DOUBLE PRECISION,
+    "longitude" DOUBLE PRECISION,
+    "phone" TEXT,
+    "metro" TEXT,
+    "access" TEXT,
+    "imageUrl" TEXT,
+    "sourceUrl" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Venue_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Venue_offiId_key" ON "Venue"("offiId");
+CREATE UNIQUE INDEX "Venue_sourceUrl_key" ON "Venue"("sourceUrl");
+CREATE INDEX "Venue_kind_idx" ON "Venue"("kind");
+
+ALTER TABLE "Work" ADD COLUMN "venueId" TEXT;
+CREATE INDEX "Work_venueId_idx" ON "Work"("venueId");
+ALTER TABLE "Work" ADD CONSTRAINT "Work_venueId_fkey" FOREIGN KEY ("venueId") REFERENCES "Venue"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -92,6 +92,11 @@ model Work {
   currency  String?        // devise du prix : "EUR"
   sourceUrl String    @unique
 
+  // Lien vers le lieu (pertinent surtout pour le théâtre : un spectacle = un lieu ;
+  // un film joue dans plusieurs cinémas, donc les œuvres ciné restent non liées).
+  venue_ref Venue?  @relation(fields: [venueId], references: [id], onDelete: SetNull)
+  venueId   String?
+
   // ✅ Réactions (remplace l'ancien Work.likes)
   reactions Reaction[] @relation("WorkReactions")
 
@@ -99,6 +104,37 @@ model Work {
   updatedAt DateTime @updatedAt
 
   @@index([section, createdAt])
+  @@index([venueId])
+}
+
+// Lieu (théâtre ou cinéma) — catalogue avec infos pratiques scrapées sur offi.
+// Même forme pour les deux segments → un seul modèle discriminé par `kind`.
+model Venue {
+  id     String @id @default(cuid())
+  offiId Int    @unique          // identifiant offi (ex. 2490)
+  kind   String                   // 'theatre' | 'cinema'
+  name   String
+
+  streetAddress String?
+  postalCode    String?
+  city          String?           // addressLocality, ex. "Paris 5e"
+  country       String?           // addressCountry, ex. "FR"
+  latitude      Float?
+  longitude     Float?
+
+  phone  String?
+  metro  String?
+  access String?                  // "Accès PMR, Espace climatisé"
+
+  imageUrl  String?
+  sourceUrl String @unique
+
+  works Work[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([kind])
 }
 
 // ✅ Enum de statut : un seul état par (user, work)

--- a/app/scripts/backfill-venues.ts
+++ b/app/scripts/backfill-venues.ts
@@ -1,0 +1,181 @@
+// Backfill / ingestion des lieux (Venue) depuis offi, + lien Work.venueId (théâtre).
+//
+// - Théâtre : l'URL de la page lieu se déduit de l'URL du spectacle
+//   (/theatre/<venue>-<id>/<show>.html → /theatre/<venue>-<id>.html). On upsert le
+//   lieu et on relie tous les spectacles de ce lieu (venueId).
+// - Cinéma : un film joue dans plusieurs salles → pas de lien 1:1. On récolte les
+//   salles listées sur les fiches films (catalogue uniquement).
+//
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/backfill-venues.ts [theatre|cinema|all] [limit]
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { prisma } from '@/server/db'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const scraperDir = path.resolve(here, '../../scraper')
+const PY = path.join(scraperDir, '.venv/bin/python')
+const CLI = path.join(scraperDir, 'extract_venue_cli.py')
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+
+const mode = (process.argv[2] ?? 'all') as 'theatre' | 'cinema' | 'all'
+const limit = Number(process.argv[3] ?? 1000)
+
+type VenueData = {
+  offi_id: number
+  kind: string
+  name: string
+  street_address: string | null
+  postal_code: string | null
+  city: string | null
+  country: string | null
+  latitude: number | null
+  longitude: number | null
+  phone: string | null
+  metro: string | null
+  access: string | null
+  image: string | null
+  source_url: string
+}
+
+function theatreVenueUrlFromShow(url: string): string | null {
+  const m = url.match(/^(https?:\/\/[^/]+\/theatre\/[^/]+-\d+)\/[^/]+-\d+(?:\.html)?$/)
+  return m ? `${m[1]}.html` : null
+}
+
+function cinemaVenueLinks(html: string): string[] {
+  const out = new Set<string>()
+  const re = /\/cinema\/(?!evenement\/)[a-z0-9-]+-\d+\.html/g
+  for (const m of html.matchAll(re)) out.add(`https://www.offi.fr${m[0]}`)
+  return [...out]
+}
+
+async function fetchHtml(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(15_000) })
+    return res.ok ? await res.text() : null
+  } catch {
+    return null
+  }
+}
+
+function extractVenue(html: string, url: string, kind: string): VenueData | null {
+  const res = spawnSync(PY, [CLI, url, kind], {
+    input: html,
+    encoding: 'utf-8',
+    cwd: scraperDir,
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 10_000,
+    killSignal: 'SIGKILL',
+  })
+  if (res.status !== 0 || !res.stdout) return null
+  try {
+    const parsed = JSON.parse(res.stdout)
+    return parsed && parsed.offi_id ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+async function upsertVenue(v: VenueData): Promise<string> {
+  const data = {
+    offiId: v.offi_id,
+    kind: v.kind,
+    name: v.name,
+    streetAddress: v.street_address,
+    postalCode: v.postal_code,
+    city: v.city,
+    country: v.country,
+    latitude: v.latitude,
+    longitude: v.longitude,
+    phone: v.phone,
+    metro: v.metro,
+    access: v.access,
+    imageUrl: v.image,
+    sourceUrl: v.source_url,
+  }
+  const venue = await prisma.venue.upsert({ where: { offiId: v.offi_id }, create: data, update: data })
+  return venue.id
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function backfillTheatre() {
+  const works = await prisma.work.findMany({
+    where: { section: 'theatre' },
+    select: { id: true, sourceUrl: true },
+  })
+  // Regroupe les spectacles par URL de lieu déduite.
+  const byVenueUrl = new Map<string, string[]>()
+  for (const w of works) {
+    const venueUrl = theatreVenueUrlFromShow(w.sourceUrl)
+    if (!venueUrl) continue
+    const list = byVenueUrl.get(venueUrl) ?? []
+    list.push(w.id)
+    byVenueUrl.set(venueUrl, list)
+  }
+
+  // Ne (re)traite que les lieux pas encore en base, dans la limite demandée.
+  const existing = new Set((await prisma.venue.findMany({ where: { kind: 'theatre' }, select: { sourceUrl: true } })).map((v) => v.sourceUrl))
+  const urls = [...byVenueUrl.keys()].filter((u) => !existing.has(u)).slice(0, limit)
+
+  let venues = 0
+  let linked = 0
+  for (const url of urls) {
+    const html = await fetchHtml(url)
+    if (!html) continue
+    const v = extractVenue(html, url, 'theatre')
+    if (!v) continue
+    const venueId = await upsertVenue(v)
+    venues += 1
+    const workIds = byVenueUrl.get(url) ?? []
+    const res = await prisma.work.updateMany({ where: { id: { in: workIds } }, data: { venueId } })
+    linked += res.count
+    await sleep(350)
+  }
+  console.log(JSON.stringify({ segment: 'theatre', venues, linkedWorks: linked, candidates: urls.length }))
+}
+
+async function backfillCinema() {
+  // Récolte les URLs de salles depuis les fiches films récentes.
+  const films = await prisma.work.findMany({
+    where: { section: 'cinema' },
+    select: { sourceUrl: true },
+    orderBy: { createdAt: 'desc' },
+    take: 200,
+  })
+  const venueUrls = new Set<string>()
+  for (const f of films) {
+    const html = await fetchHtml(f.sourceUrl)
+    if (html) cinemaVenueLinks(html).forEach((u) => venueUrls.add(u))
+    await sleep(250)
+    if (venueUrls.size >= limit) break
+  }
+
+  const existing = new Set((await prisma.venue.findMany({ where: { kind: 'cinema' }, select: { sourceUrl: true } })).map((v) => v.sourceUrl))
+  const urls = [...venueUrls].filter((u) => !existing.has(u)).slice(0, limit)
+
+  let venues = 0
+  for (const url of urls) {
+    const html = await fetchHtml(url)
+    if (!html) continue
+    const v = extractVenue(html, url, 'cinema')
+    if (!v) continue
+    await upsertVenue(v)
+    venues += 1
+    await sleep(350)
+  }
+  console.log(JSON.stringify({ segment: 'cinema', venues, harvested: venueUrls.size }))
+}
+
+async function main() {
+  if (mode === 'theatre' || mode === 'all') await backfillTheatre()
+  if (mode === 'cinema' || mode === 'all') await backfillCinema()
+}
+
+main()
+  .catch((error) => {
+    console.error('[backfill-venues]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/app/src/features/works/dto.ts
+++ b/app/src/features/works/dto.ts
@@ -23,6 +23,9 @@ export const workCardSelect = {
   availability: true,
   currency: true,
   sourceUrl: true,
+  venue_ref: {
+    select: { name: true, metro: true, access: true, phone: true, city: true },
+  },
 } satisfies Prisma.WorkSelect
 
 type WorkCardRecord = Prisma.WorkGetPayload<{ select: typeof workCardSelect }>
@@ -49,6 +52,13 @@ export type WorkCardDto = {
   availability: string | null
   currency: string | null
   sourceUrl: string | null
+  venueInfo: {
+    name: string
+    metro: string | null
+    access: string | null
+    phone: string | null
+    city: string | null
+  } | null
 }
 
 export function mapWorkToCardDto(work: WorkCardRecord): WorkCardDto {
@@ -74,5 +84,14 @@ export function mapWorkToCardDto(work: WorkCardRecord): WorkCardDto {
     availability: work.availability,
     currency: work.currency,
     sourceUrl: work.sourceUrl,
+    venueInfo: work.venue_ref
+      ? {
+          name: work.venue_ref.name,
+          metro: work.venue_ref.metro,
+          access: work.venue_ref.access,
+          phone: work.venue_ref.phone,
+          city: work.venue_ref.city,
+        }
+      : null,
   }
 }

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -25,6 +25,9 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
     .filter(Boolean)
     .join(' · ')
   const cinemaMeta = work.section === 'cinema' ? [work.country, work.year].filter(Boolean).join(' · ') : ''
+  // Infos pratiques du lieu (théâtre relié) : métro + accès.
+  const venueMetro = work.venueInfo?.metro?.trim()
+  const venueAccess = work.venueInfo?.access?.trim()
 
   return (
     <article
@@ -88,6 +91,13 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
               </p>
             ) : null}
           </div>
+        ) : null}
+
+        {venueMetro || venueAccess ? (
+          <p className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[color:var(--color-text-muted)]">
+            {venueMetro ? <span>🚇 {venueMetro}</span> : null}
+            {venueAccess ? <span>♿ {venueAccess}</span> : null}
+          </p>
         ) : null}
 
         {hasFacts ? (

--- a/app/tests/card-work.test.tsx
+++ b/app/tests/card-work.test.tsx
@@ -31,6 +31,7 @@ const base: WorkCardDto = {
   availability: null,
   currency: null,
   sourceUrl: 'https://www.offi.fr/x',
+  venueInfo: null,
 }
 
 describe('CardWork', () => {
@@ -82,6 +83,20 @@ describe('CardWork', () => {
   it('affiche « Complet » quand availability=SoldOut', () => {
     render(<CardWork work={{ ...base, availability: 'SoldOut' }} />)
     expect(screen.getByText('Complet')).toBeInTheDocument()
+  })
+
+  it('affiche les infos pratiques du lieu (métro + accès)', () => {
+    render(
+      <CardWork
+        work={{
+          ...base,
+          section: 'theatre',
+          venueInfo: { name: 'Théâtre de la Huchette', metro: 'Cluny - La Sorbonne', access: 'Accès PMR', phone: null, city: 'Paris 5e' },
+        }}
+      />,
+    )
+    expect(screen.getByText(/Cluny - La Sorbonne/)).toBeInTheDocument()
+    expect(screen.getByText(/Accès PMR/)).toBeInTheDocument()
   })
 
   it('théâtre : affiche le lieu avec l’arrondissement', () => {

--- a/scraper/extract_venue_cli.py
+++ b/scraper/extract_venue_cli.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Lit le HTML d'une page lieu Offi sur stdin, imprime le lieu en JSON.
+Usage : python extract_venue_cli.py <source_url> <kind>  (kind = theatre|cinema)
+Réutilise parsers.extract_venue (même logique que le scraper) — utilisé par
+app/scripts/backfill-venues.ts."""
+import sys
+import json
+
+from bs4 import BeautifulSoup
+
+try:
+    from scraper import parsers  # contexte package
+except ImportError:  # exécuté depuis le dossier scraper/
+    import parsers  # type: ignore[no-redef]
+
+
+def main() -> None:
+    source_url = sys.argv[1] if len(sys.argv) > 1 else ""
+    kind = sys.argv[2] if len(sys.argv) > 2 else "theatre"
+    venue = parsers.extract_venue(BeautifulSoup(sys.stdin.read(), "html.parser"), source_url, kind)
+    print(json.dumps(venue, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/parsers.py
+++ b/scraper/parsers.py
@@ -277,3 +277,118 @@ def extract_offers(soup) -> dict:
         "price_min": price_min,
         "price_max": price_max,
     }
+
+
+# --- Lieux (théâtres / cinémas) -------------------------------------------------
+# Pages lieu : /theatre/<slug>-<id>.html et /cinema/<slug>-<id>.html. Même forme
+# (nom, adresse structurée, géo, téléphone, métro, accès, image HD /lieu/<id>/).
+
+_OFFI_ID_RE = re.compile(r"-(\d+)(?:\.html)?(?:[?#].*)?$")
+_PHONE_RE = re.compile(r"\+?\d[\d .]{7,}\d")
+_METRO_RE = re.compile(r"M[ée]tro\s*:?\s*([A-Za-zÀ-ÿ0-9 '’\-]{3,60})", re.IGNORECASE)
+
+
+def offi_id_from_url(url: Optional[str]) -> Optional[int]:
+    if not url:
+        return None
+    match = _OFFI_ID_RE.search(url.strip())
+    return int(match.group(1)) if match else None
+
+
+def theatre_venue_url_from_show(url: Optional[str]) -> Optional[str]:
+    """Déduit l'URL de la page lieu depuis l'URL d'un spectacle de théâtre.
+    /theatre/<venue>-<vid>/<show>-<sid>.html -> /theatre/<venue>-<vid>.html"""
+    m = re.match(r"^(https?://[^/]+/theatre/[^/]+-\d+)/[^/]+-\d+(?:\.html)?$", (url or "").strip())
+    return f"{m.group(1)}.html" if m else None
+
+
+def cinema_venue_links(soup) -> list[tuple[str, int]]:
+    """Liste (url, offi_id) des salles de cinéma référencées sur une fiche film."""
+    seen: dict[int, str] = {}
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        m = re.search(r"/cinema/(?!evenement/)[a-z0-9\-]+-(\d+)\.html", href)
+        if not m:
+            continue
+        vid = int(m.group(1))
+        url = href if href.startswith("http") else f"https://www.offi.fr{href}"
+        url = url.split("#", 1)[0]
+        seen.setdefault(vid, url)
+    return [(url, vid) for vid, url in seen.items()]
+
+
+def _venue_access_features(text: str) -> Optional[str]:
+    features: list[str] = []
+    if re.search(r"\bPMR\b", text):
+        features.append("Accès PMR")
+    if re.search(r"climatis", text, re.IGNORECASE):
+        features.append("Espace climatisé")
+    return ", ".join(features) or None
+
+
+def extract_venue(soup, source_url: str, kind: str) -> Optional[dict]:
+    """Extrait les infos d'une page lieu (BeautifulSoup) → dict, ou None si pas de nom."""
+    offi_id = offi_id_from_url(source_url)
+    if offi_id is None:
+        return None
+
+    h1 = soup.select_one("h1")
+    name = _clean_credit(h1.get_text(" ", strip=True)) if h1 else None
+    if not name:
+        return None
+
+    def ip(n: str) -> Optional[str]:
+        return _itemprop_value(soup, n)
+
+    street = _clean_credit(ip("streetAddress") or "") or None
+    postal = _clean_credit(ip("postalCode") or "") or None
+    city = _clean_credit(ip("addressLocality") or "") or None
+    country = _clean_credit(ip("addressCountry") or "") or None
+
+    def to_float(v: Optional[str]) -> Optional[float]:
+        try:
+            return float(v) if v else None
+        except ValueError:
+            return None
+
+    # itemprops géo capitalisés sur offi ("Latitude"/"Longitude").
+    latitude = to_float(ip("Latitude") or ip("latitude"))
+    longitude = to_float(ip("Longitude") or ip("longitude"))
+
+    phone = None
+    raw_phone = ip("telephone")
+    if raw_phone:
+        pm = _PHONE_RE.search(raw_phone)
+        if pm:
+            phone = re.sub(r"\s+", " ", pm.group(0)).strip()
+
+    text = soup.get_text(" ", strip=True)
+    metro = None
+    mm = _METRO_RE.search(text)
+    if mm:
+        # On coupe à la rubrique suivante (Accès, Bus, Parking, RER…).
+        metro = re.split(r"\s+(?:Acc[èe]s|Bus|Parking|Voiture|RER|Horaires|T[ée]l)\b", mm.group(1))[0]
+        metro = _clean_credit(metro) or None
+    access = _venue_access_features(text)
+
+    image = None
+    og = soup.find("meta", property="og:image")
+    if og and og.get("content"):
+        image = og["content"].strip()
+
+    return {
+        "offi_id": offi_id,
+        "kind": kind,
+        "name": name,
+        "street_address": street,
+        "postal_code": postal,
+        "city": city,
+        "country": country,
+        "latitude": latitude,
+        "longitude": longitude,
+        "phone": phone,
+        "metro": metro,
+        "access": access,
+        "image": image,
+        "source_url": source_url,
+    }

--- a/scraper/tests/test_parsers.py
+++ b/scraper/tests/test_parsers.py
@@ -169,5 +169,63 @@ class ExtractOffersTests(unittest.TestCase):
         self.assertEqual(o, {"availability": None, "currency": None, "price_min": None, "price_max": None})
 
 
+class VenueTests(unittest.TestCase):
+    def test_offi_id_from_url(self):
+        self.assertEqual(parsers.offi_id_from_url("https://www.offi.fr/cinema/le-chaplin-3113.html"), 3113)
+        self.assertEqual(parsers.offi_id_from_url("https://www.offi.fr/theatre/x-2490.html"), 2490)
+        self.assertIsNone(parsers.offi_id_from_url("https://www.offi.fr/theatre/"))
+
+    def test_theatre_venue_url_from_show(self):
+        url = "https://www.offi.fr/theatre/theatre-de-la-huchette-2490/crime-et-chatiment-105182.html"
+        self.assertEqual(
+            parsers.theatre_venue_url_from_show(url),
+            "https://www.offi.fr/theatre/theatre-de-la-huchette-2490.html",
+        )
+        self.assertIsNone(parsers.theatre_venue_url_from_show("https://www.offi.fr/theatre/x-2490.html"))
+
+    def test_cinema_venue_links(self):
+        html = (
+            '<a href="/cinema/le-chaplin-3113.html">Le Chaplin</a>'
+            '<a href="/cinema/le-chaplin-3113.html#onglet-acces">accès</a>'
+            '<a href="https://www.offi.fr/cinema/ugc-velizy-3340.html">UGC</a>'
+            '<a href="/cinema/evenement/film-104603.html">un film</a>'
+        )
+        links = sorted(parsers.cinema_venue_links(_soup(html)))
+        self.assertEqual(
+            links,
+            [
+                ("https://www.offi.fr/cinema/le-chaplin-3113.html", 3113),
+                ("https://www.offi.fr/cinema/ugc-velizy-3340.html", 3340),
+            ],
+        )
+
+    def test_extract_venue(self):
+        html = (
+            '<h1>Le Chaplin - Saint-Lambert</h1>'
+            '<span itemprop="streetAddress">6 rue Péclet</span>'
+            '<span itemprop="postalCode">75015</span>'
+            '<span itemprop="addressLocality">Paris 15e</span>'
+            '<span itemprop="addressCountry">FR</span>'
+            '<meta itemprop="Latitude" content="48.8432">'
+            '<meta itemprop="Longitude" content="2.2985">'
+            '<span itemprop="telephone">01.42.50.23.32 (tlj 13h30-21h)</span>'
+            '<p>Métro : Commerce Accès PMR, salle climatisée</p>'
+            '<meta property="og:image" content="https://files.offi.fr/lieu/3113/images/1000/x.jpg">'
+        )
+        v = parsers.extract_venue(_soup(html), "https://www.offi.fr/cinema/le-chaplin-3113.html", "cinema")
+        self.assertEqual(v["offi_id"], 3113)
+        self.assertEqual(v["name"], "Le Chaplin - Saint-Lambert")
+        self.assertEqual(v["postal_code"], "75015")
+        self.assertEqual(v["city"], "Paris 15e")
+        self.assertEqual(v["latitude"], 48.8432)
+        self.assertEqual(v["phone"], "01.42.50.23.32")
+        self.assertEqual(v["metro"], "Commerce")  # coupé à la rubrique suivante
+        self.assertEqual(v["access"], "Accès PMR, Espace climatisé")
+        self.assertTrue(v["image"].endswith("x.jpg"))
+
+    def test_extract_venue_requires_name(self):
+        self.assertIsNone(parsers.extract_venue(_soup("<div>no h1</div>"), "https://www.offi.fr/cinema/x-1.html", "cinema"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Crée une **base de données des lieux** (théâtres + cinémas) avec toutes leurs infos relatives sur offi.

## Modélisation
Théâtres et cinémas ont une forme identique sur offi → **un seul modèle `Venue` discriminé par `kind`** (validé avec toi).
- `Venue` : `offiId`, `kind`, `name`, adresse (rue/CP/ville/pays), **géo** (lat/long), **téléphone**, **métro**, **accès** (PMR/clim), **image HD**, `sourceUrl`.
- **Théâtre** : un spectacle = un lieu → `Work.venueId` relié (URL lieu déduite de l URL du spectacle). Affichage **🚇 métro + ♿ accès** sur la carte.
- **Cinéma** : un film joue dans plusieurs salles → pas de lien 1:1, **catalogue indépendant** (salles récoltées sur les fiches films).

## Chaîne
- `scraper/parsers.py` : `extract_venue`, `theatre_venue_url_from_show`, `cinema_venue_links`, `offi_id_from_url` (pures, **+5 tests → 41 scraper**, sanity-check sur vraies pages OK).
- `extract_venue_cli.py` ; `scripts/backfill-venues.ts` (théâtre relié + ciné catalogue).
- DTO `workCardSelect` : relation `venue_ref` → `venueInfo` (métro/accès/tél/ville).
- Migration `add_venue` (table + index + FK `Work.venueId` ON DELETE SET NULL ; **appliquée sur Neon**).

lint/typecheck verts ; **92 tests app + 41 tests scraper** verts. Backfill des lieux en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)