### PR TITLE
ci: automatisation du refresh offi (GitHub Actions cron)

### DIFF
--- a/.github/workflows/offi-refresh.yml
+++ b/.github/workflows/offi-refresh.yml
@@ -1,0 +1,97 @@
+name: Offi refresh
+
+# Rafraîchit les données offi → Neon, automatiquement.
+#   - Quotidien 05:30 UTC (07:30 Paris l'été / 06:30 l'hiver) : pipeline œuvres
+#     (scrape → migrations Prisma → ingestion). Capte les sorties ciné du mercredi,
+#     les nouveaux spectacles et la dispo billetterie.
+#   - Hebdomadaire (dimanche) : rafraîchit le catalogue des lieux + relie les œuvres.
+#
+# Pré-requis : secret de dépôt DATABASE_URL (chaîne de connexion Neon).
+# Le cache JSONL est persisté entre les runs (actions/cache) pour profiter du
+# rafraîchissement incrémental à 72 h du scraper (poli envers offi.fr).
+
+on:
+  schedule:
+    - cron: '30 5 * * *'      # tous les jours — œuvres
+    - cron: '0 6 * * 0'       # dimanche — lieux
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'works | venues | all'
+        required: false
+        default: 'works'
+
+concurrency:
+  group: offi-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # env.ts exige NEXTAUTH_SECRET ; l'ingestion ne l'utilise pas → placeholder
+      # si le secret n'est pas défini, pour ne dépendre que de DATABASE_URL.
+      NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'ci-ingestion-placeholder' }}
+      OFFI_PYTHON_BIN: python3
+      OFFI_MAX_PAGES: '150'
+      OFFI_REFRESH_AFTER_HOURS: '72'
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          package-manager-cache: false
+      - run: corepack enable
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r scraper/requirements.txt
+
+      - name: Install app deps (postinstall → prisma generate)
+        working-directory: app
+        run: pnpm install --frozen-lockfile
+
+      # Persiste data/offi.jsonl entre les runs (clé unique par run, restaure le plus récent).
+      - name: Restore JSONL cache
+        uses: actions/cache@v4
+        with:
+          path: data/offi.jsonl
+          key: offi-jsonl-${{ github.run_id }}
+          restore-keys: |
+            offi-jsonl-
+
+      - name: Decide targets
+        id: plan
+        run: |
+          # cron quotidien → works ; cron hebdo (dimanche 06:00) → venues ;
+          # déclenchement manuel → input.target.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            if [ "${{ github.event.schedule }}" = "0 6 * * 0" ]; then
+              echo "do_works=false" >> "$GITHUB_OUTPUT"
+              echo "do_venues=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "do_works=true" >> "$GITHUB_OUTPUT"
+              echo "do_venues=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            case "${{ github.event.inputs.target }}" in
+              venues) echo "do_works=false" >> "$GITHUB_OUTPUT"; echo "do_venues=true" >> "$GITHUB_OUTPUT" ;;
+              all)    echo "do_works=true"  >> "$GITHUB_OUTPUT"; echo "do_venues=true" >> "$GITHUB_OUTPUT" ;;
+              *)      echo "do_works=true"  >> "$GITHUB_OUTPUT"; echo "do_venues=false" >> "$GITHUB_OUTPUT" ;;
+            esac
+          fi
+
+      - name: Refresh works (scrape → migrate → ingest)
+        if: steps.plan.outputs.do_works == 'true'
+        run: ./scripts/offi-pipeline.sh
+
+      - name: Refresh venues catalog + relink
+        if: steps.plan.outputs.do_venues == 'true'
+        working-directory: app
+        run: |
+          pnpm exec prisma migrate deploy --schema prisma/schema.prisma
+          pnpm exec tsx scripts/backfill-venues.ts all 2000

--- a/app/scripts/backfill-venues.ts
+++ b/app/scripts/backfill-venues.ts
@@ -43,6 +43,12 @@ function theatreVenueUrlFromShow(url: string): string | null {
   return m ? `${m[1]}.html` : null
 }
 
+function offiIdFromUrl(url: string | null): number | null {
+  if (!url) return null
+  const m = url.match(/-(\d+)(?:\.html)?(?:[?#].*)?$/)
+  return m ? Number(m[1]) : null
+}
+
 function cinemaVenueLinks(html: string): string[] {
   const out = new Set<string>()
   const re = /\/cinema\/(?!evenement\/)[a-z0-9-]+-\d+\.html/g
@@ -133,7 +139,31 @@ async function backfillTheatre() {
     linked += res.count
     await sleep(350)
   }
-  console.log(JSON.stringify({ segment: 'theatre', venues, linkedWorks: linked, candidates: urls.length }))
+
+  // Relink (sans fetch) : spectacles encore non liés dont le lieu est déjà en base.
+  // Couvre les nouveaux spectacles ajoutés dans un lieu déjà connu.
+  const knownVenues = await prisma.venue.findMany({ where: { kind: 'theatre' }, select: { id: true, offiId: true } })
+  const venueIdByOffiId = new Map(knownVenues.map((v) => [v.offiId, v.id]))
+  const unlinked = await prisma.work.findMany({
+    where: { section: 'theatre', venueId: null },
+    select: { id: true, sourceUrl: true },
+  })
+  const relinkGroups = new Map<string, string[]>()
+  for (const w of unlinked) {
+    const offiId = offiIdFromUrl(theatreVenueUrlFromShow(w.sourceUrl))
+    const vid = offiId != null ? venueIdByOffiId.get(offiId) : undefined
+    if (!vid) continue
+    const list = relinkGroups.get(vid) ?? []
+    list.push(w.id)
+    relinkGroups.set(vid, list)
+  }
+  let relinked = 0
+  for (const [vid, ids] of relinkGroups) {
+    const res = await prisma.work.updateMany({ where: { id: { in: ids } }, data: { venueId: vid } })
+    relinked += res.count
+  }
+
+  console.log(JSON.stringify({ segment: 'theatre', venues, linkedWorks: linked, relinked, candidates: urls.length }))
 }
 
 async function backfillCinema() {


### PR DESCRIPTION
Automatise le rafraîchissement des données offi → Neon via GitHub Actions (le pipeline `offi-pipeline.sh` existait déjà, il manquait le déclencheur).

## `.github/workflows/offi-refresh.yml`
- **Quotidien** (05:30 UTC ≈ 07:30 Paris) : pipeline **œuvres** (scrape → migrations Prisma → ingestion). Capte les sorties ciné du mercredi, les nouveaux spectacles et la dispo billetterie.
- **Hebdomadaire** (dimanche) : rafraîchit le **catalogue des lieux** + relink.
- **`workflow_dispatch`** manuel (`works` | `venues` | `all`).
- **Cache JSONL persisté** (`actions/cache`) → profite du rafraîchissement incrémental à 72 h du scraper (poli envers offi.fr).
- Ne dépend que du secret **`DATABASE_URL`** (`NEXTAUTH_SECRET` a un fallback placeholder, non utilisé par l ingestion).

## Aussi
`scripts/backfill-venues.ts` : passe de **relink sans fetch** (relie les spectacles non liés à un lieu déjà en base → couvre les nouveaux spectacles d un lieu déjà connu).

## ⚠️ Action requise après merge
Ajouter le secret de dépôt **`DATABASE_URL`** : Settings → Secrets and variables → Actions → New repository secret (chaîne Neon, idéalement avec `?sslmode=require`).

lint/typecheck/tests verts ; YAML validé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)