### PR TITLE
fix(ci): offi-refresh en Node 22 (Prisma 7 → node:sqlite)

### DIFF
--- a/.github/workflows/offi-refresh.yml
+++ b/.github/workflows/offi-refresh.yml
@@ -42,7 +42,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          # Node 22 requis : Prisma 7 (migrate deploy) importe node:sqlite,
+          # absent de Node 20 (ERR_UNKNOWN_BUILTIN_MODULE). Le local tourne en 22.
+          node-version: 22
           package-manager-cache: false
       - run: corepack enable
 


### PR DESCRIPTION
Le premier run du cron a échoué à l étape **migrations Prisma** : `Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite`. Prisma 7 (`migrate deploy`) importe `node:sqlite`, **absent de Node 20** ; le local tourne en Node 22.

Le scrape réussissait (128 pages, 1865 fiches) mais `db:deploy` plantait **avant** l ingestion → Neon inchangé. Ce fix aligne le workflow sur **Node 22**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)