### PR TITLE
feat(ux): refonte /likes — shortlist actionnable (cartes compactes + modale)

### DIFF
--- a/app/src/app/likes/page.tsx
+++ b/app/src/app/likes/page.tsx
@@ -1,5 +1,5 @@
 import { requireSessionUserOrRedirect } from '@/features/auth/server/session'
-import { listLikedWorks } from '@/features/reactions/server/queries'
+import { friendsWhoLiked, listLibraryWorks } from '@/features/reactions/server/queries'
 import LikesLibrary from '@/features/reactions/ui/LikesLibrary'
 import { isWorkCurrentlyShowing } from '@/features/works/availability'
 
@@ -9,11 +9,11 @@ type LikesPageProps = {
   }>
 }
 
-type LikesView = 'all' | 'active' | 'archived'
+type LikesView = 'all' | 'active' | 'archived' | 'seen'
 
 function resolveLikesView(value: string | string[] | undefined): LikesView {
   const candidate = Array.isArray(value) ? value[0] : value
-  if (candidate === 'active' || candidate === 'archived') {
+  if (candidate === 'active' || candidate === 'archived' || candidate === 'seen') {
     return candidate
   }
   return 'all'
@@ -24,13 +24,17 @@ export default async function LikesPage({ searchParams }: LikesPageProps = {}) {
 
   const resolvedSearchParams = searchParams ? await searchParams : undefined
   const view = resolveLikesView(resolvedSearchParams?.view)
-  const likes = await listLikedWorks(sessionUser.id)
-  const currentLikes = likes.filter((like) => isWorkCurrentlyShowing(like.work?.endDate))
-  const archivedLikes = likes.filter((like) => !isWorkCurrentlyShowing(like.work?.endDate))
+
+  const { likes, seen } = await listLibraryWorks(sessionUser.id)
+  const current = likes.filter((like) => isWorkCurrentlyShowing(like.work?.endDate))
+  const archived = likes.filter((like) => !isWorkCurrentlyShowing(like.work?.endDate))
+
+  const allWorkIds = [...likes, ...seen].map((item) => item.workId)
+  const friendsByWork = await friendsWhoLiked(sessionUser.id, allWorkIds)
 
   return (
     <div className="page-shell">
-      <LikesLibrary current={currentLikes} archived={archivedLikes} view={view} />
+      <LikesLibrary current={current} archived={archived} seen={seen} friendsByWork={friendsByWork} view={view} />
     </div>
   )
 }

--- a/app/src/features/reactions/server/queries.ts
+++ b/app/src/features/reactions/server/queries.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { prisma } from '@/server/db'
+import type { FriendSummaryDto } from '@/features/friendships/dto'
 import { mapWorkToCardDto, workCardSelect } from '@/features/works/dto'
 
 export type LikedWorkItem = {
@@ -24,4 +25,51 @@ export async function listLikedWorks(userId: string): Promise<LikedWorkItem[]> {
     workId: like.workId,
     work: like.work ? mapWorkToCardDto(like.work) : null,
   }))
+}
+
+// Bibliothèque /likes : likes (à voir) + œuvres marquées vues (déjà vues), en une requête.
+export async function listLibraryWorks(userId: string): Promise<{ likes: LikedWorkItem[]; seen: LikedWorkItem[] }> {
+  const rows = await prisma.reaction.findMany({
+    where: { userId, status: { in: ['LIKE', 'SEEN'] } },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      workId: true,
+      status: true,
+      work: { select: workCardSelect },
+    },
+  })
+
+  const likes: LikedWorkItem[] = []
+  const seen: LikedWorkItem[] = []
+  for (const row of rows) {
+    const item = { workId: row.workId, work: row.work ? mapWorkToCardDto(row.work) : null }
+    ;(row.status === 'SEEN' ? seen : likes).push(item)
+  }
+  return { likes, seen }
+}
+
+// Pour un ensemble d'œuvres, quels amis (amitié ACCEPTED) les ont aussi likées.
+export async function friendsWhoLiked(
+  userId: string,
+  workIds: string[],
+): Promise<Record<string, FriendSummaryDto[]>> {
+  const result: Record<string, FriendSummaryDto[]> = {}
+  if (workIds.length === 0) return result
+
+  const friendships = await prisma.friendship.findMany({
+    where: { userId, status: 'ACCEPTED' },
+    select: { friendId: true },
+  })
+  const friendIds = friendships.map((f) => f.friendId)
+  if (friendIds.length === 0) return result
+
+  const reactions = await prisma.reaction.findMany({
+    where: { userId: { in: friendIds }, status: 'LIKE', workId: { in: workIds } },
+    select: { workId: true, user: { select: { id: true, email: true } } },
+  })
+
+  for (const r of reactions) {
+    ;(result[r.workId] ??= []).push(r.user)
+  }
+  return result
 }

--- a/app/src/features/reactions/ui/CompactLikeCard.tsx
+++ b/app/src/features/reactions/ui/CompactLikeCard.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import Image from 'next/image'
+import type { FriendSummaryDto } from '@/features/friendships/dto'
+import type { WorkCardDto } from '@/features/works/dto'
+import { formatAvailability, formatEndsIn, formatPriceRange } from '@/features/works/ui/work-formatters'
+
+function initials(email: string) {
+  return (email.split('@')[0] ?? email).slice(0, 2).toUpperCase()
+}
+
+type Props = {
+  work: WorkCardDto | null
+  fallbackTitle: string
+  friends: FriendSummaryDto[]
+  onOpen: () => void
+}
+
+// Carte compacte et cliquable (le détail s'ouvre dans une modale). Vignette à
+// gauche, titre + signaux d'action à droite (urgence, dispo, prix, amis).
+export default function CompactLikeCard({ work, fallbackTitle, friends, onOpen }: Props) {
+  const title = work?.title ?? fallbackTitle
+  const sectionLabel = work?.section === 'cinema' ? 'Cinéma' : 'Théâtre'
+  const ends = formatEndsIn(work?.endDate ?? null)
+  const availability = formatAvailability(work?.availability ?? null)
+  const priceLabel = formatPriceRange(work?.priceMin ?? null, work?.priceMax ?? null)
+  const metaLine =
+    work?.section === 'cinema'
+      ? [work?.country, work?.year].filter(Boolean).join(' · ')
+      : [work?.venue, work?.arrondissement].filter(Boolean).join(' · ')
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="group flex w-full items-stretch gap-3 overflow-hidden rounded-[var(--radius-lg)] border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-2 text-left transition hover:border-[color:var(--color-border-strong)] hover:shadow-[var(--shadow-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]"
+      aria-label={`Voir le détail de ${title}`}
+    >
+      <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-[var(--radius-md)] bg-muted">
+        {work?.imageUrl ? (
+          <Image src={work.imageUrl} alt="" fill sizes="80px" className="object-cover" />
+        ) : (
+          <div className="flex h-full items-center justify-center text-[0.65rem] text-muted-foreground">—</div>
+        )}
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-1 py-0.5 pr-1">
+        <div className="flex items-center gap-2">
+          <span className="text-[0.62rem] font-semibold uppercase tracking-[0.1em] text-[color:var(--color-text-muted)]">
+            {sectionLabel}
+          </span>
+          {priceLabel ? <span className="text-[0.62rem] text-[color:var(--color-text-muted)]">· {priceLabel}</span> : null}
+        </div>
+
+        <h3 className="line-clamp-2 text-sm font-semibold leading-tight tracking-[-0.02em] text-[color:var(--color-text)]">
+          {title}
+        </h3>
+
+        {metaLine ? <p className="truncate text-xs text-[color:var(--color-text-muted)]">{metaLine}</p> : null}
+
+        <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-1">
+          {ends ? (
+            <span
+              className={`rounded-full px-2 py-0.5 text-[0.62rem] font-semibold ${
+                ends.urgent
+                  ? 'bg-[color:var(--color-danger-soft)] text-[color:var(--color-danger)]'
+                  : 'bg-[rgba(54,39,24,0.06)] text-[color:var(--color-text)]'
+              }`}
+            >
+              ⏳ {ends.label}
+            </span>
+          ) : null}
+          {availability ? (
+            <span
+              className={`rounded-full px-2 py-0.5 text-[0.62rem] font-semibold ${
+                availability.tone === 'success'
+                  ? 'bg-[color:var(--color-success-soft)] text-[color:var(--color-success)]'
+                  : 'bg-[color:var(--color-danger-soft)] text-[color:var(--color-danger)]'
+              }`}
+            >
+              {availability.label}
+            </span>
+          ) : null}
+          {friends.length > 0 ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-[rgba(15,93,94,0.10)] px-2 py-0.5 text-[0.62rem] font-semibold text-[color:var(--color-accent)]">
+              <span aria-hidden>👥</span>
+              {friends.length === 1 ? initials(friends[0].email) : `${friends.length} amis`}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/app/src/features/reactions/ui/LikeDetailModal.tsx
+++ b/app/src/features/reactions/ui/LikeDetailModal.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type { FriendSummaryDto } from '@/features/friendships/dto'
+import type { WorkCardDto } from '@/features/works/dto'
+import WorkSummaryCard from '@/features/works/ui/WorkSummaryCard'
+import { formatAvailability } from '@/features/works/ui/work-formatters'
+
+export type LikeBucket = 'like' | 'seen'
+
+type Props = {
+  work: WorkCardDto | null
+  fallbackTitle: string
+  friends: FriendSummaryDto[]
+  bucket: LikeBucket
+  onClose: () => void
+  onSeen: () => void
+  onRemove: () => void
+}
+
+function mapsUrl(work: WorkCardDto) {
+  const query = [work.venue, work.address, work.arrondissement, 'Paris'].filter(Boolean).join(' ')
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
+}
+
+export default function LikeDetailModal({ work, fallbackTitle, friends, bucket, onClose, onSeen, onRemove }: Props) {
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  // Fermeture au clavier (Échap) + focus initial sur le bouton fermer.
+  useEffect(() => {
+    closeRef.current?.focus()
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const title = work?.title ?? fallbackTitle
+  const availability = formatAvailability(work?.availability ?? null)
+  const soldOut = work?.availability === 'SoldOut' || work?.availability === 'OutOfStock'
+  const venueMetro = work?.venueInfo?.metro?.trim()
+  const venueAccess = work?.venueInfo?.access?.trim()
+  const venuePhone = work?.venueInfo?.phone?.trim()
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 backdrop-blur-sm sm:items-center sm:p-4"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Détail : ${title}`}
+        className="max-h-[92vh] w-full max-w-xl overflow-y-auto rounded-t-[var(--radius-2xl)] bg-[color:var(--color-page)] p-4 shadow-[var(--shadow-lg)] sm:rounded-[var(--radius-2xl)]"
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <span className="chip">{bucket === 'seen' ? 'Déjà vu' : 'Dans mes likes'}</span>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Fermer"
+            className="btn btn-ghost px-3 py-1.5 text-sm"
+          >
+            ✕ Fermer
+          </button>
+        </div>
+
+        <WorkSummaryCard
+          work={work}
+          fallbackTitle={fallbackTitle}
+          actions={
+            <div className="space-y-4">
+              {/* Infos pratiques (lieu relié) */}
+              {venueMetro || venueAccess || venuePhone ? (
+                <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[color:var(--color-text-muted)]">
+                  {venueMetro ? <span>🚇 {venueMetro}</span> : null}
+                  {venueAccess ? <span>♿ {venueAccess}</span> : null}
+                  {venuePhone ? <span>📞 {venuePhone}</span> : null}
+                </div>
+              ) : null}
+
+              {/* Amis qui aiment aussi */}
+              {friends.length > 0 ? (
+                <p className="text-sm text-[color:var(--color-text)]">
+                  <span aria-hidden>👥 </span>
+                  <span className="text-muted-foreground">Aimé aussi par </span>
+                  <span className="font-medium">{friends.map((f) => f.email.split('@')[0]).join(', ')}</span>
+                </p>
+              ) : null}
+
+              {/* Réserver */}
+              {work?.sourceUrl ? (
+                <a
+                  href={work.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`btn ${soldOut ? 'btn-secondary' : 'btn-primary'} w-full justify-center`}
+                  aria-disabled={soldOut || undefined}
+                >
+                  {soldOut ? 'Complet — voir sur Offi.fr ↗' : availability ? 'Réserver des billets ↗' : 'Voir sur Offi.fr ↗'}
+                </a>
+              ) : null}
+
+              {work ? (
+                <a
+                  href={mapsUrl(work)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block text-center text-xs font-medium text-[color:var(--color-text-muted)] underline-offset-4 hover:text-[color:var(--color-accent)] hover:underline"
+                >
+                  📍 Itinéraire
+                </a>
+              ) : null}
+
+              {/* Actions bibliothèque */}
+              <div className="flex flex-wrap gap-2 border-t border-[color:var(--color-border)] pt-3">
+                {bucket === 'like' ? (
+                  <button type="button" className="btn btn-secondary flex-1 px-3 py-2 text-sm" onClick={onSeen}>
+                    Marquer vu
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className="btn btn-ghost flex-1 px-3 py-2 text-sm text-[color:var(--color-danger)]"
+                  onClick={onRemove}
+                >
+                  Retirer
+                </button>
+              </div>
+            </div>
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/src/features/reactions/ui/LikesLibrary.tsx
+++ b/app/src/features/reactions/ui/LikesLibrary.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { FriendSummaryDto } from '@/features/friendships/dto'
 import type { WorkCardDto } from '@/features/works/dto'
-import WorkSummaryCard from '@/features/works/ui/WorkSummaryCard'
+import CompactLikeCard from '@/features/reactions/ui/CompactLikeCard'
+import LikeDetailModal, { type LikeBucket } from '@/features/reactions/ui/LikeDetailModal'
 import { fetchJson } from '@/shared/lib/fetch-json'
 import PageHeader from '@/shared/ui/PageHeader'
 import SegmentedControl from '@/shared/ui/SegmentedControl'
@@ -13,23 +15,26 @@ export type LikedItem = {
   work: WorkCardDto | null
 }
 
-type LikesView = 'all' | 'active' | 'archived'
+type LikesView = 'all' | 'active' | 'archived' | 'seen'
 
 type Props = {
   current: LikedItem[]
   archived: LikedItem[]
+  seen: LikedItem[]
+  friendsByWork: Record<string, FriendSummaryDto[]>
   view: LikesView
 }
 
-// "Marquer vu" et "Retirer" sortent tous deux l'œuvre des likes, mais avec un sens
-// différent côté serveur (SEEN = consommée / DISLIKE = plus intéressé). Le toast
-// rend cette conséquence explicite et offre un retour arrière immédiat.
-type RemovalStatus = 'SEEN' | 'DISLIKE'
+type ReactionStatus = 'LIKE' | 'SEEN' | 'DISLIKE'
+type SourceBucket = 'active' | 'archived' | 'seen'
+type SortKey = 'recent' | 'ending' | 'price'
 
 type Toast = {
-  workId: string
+  item: LikedItem
   title: string
-  status: RemovalStatus
+  message: string
+  from: SourceBucket
+  undoStatus: 'LIKE' | 'SEEN'
 }
 
 const UNDO_WINDOW_MS = 6000
@@ -38,7 +43,7 @@ function titleOf(item: LikedItem) {
   return item.work?.title?.trim() || 'cette œuvre'
 }
 
-async function postStatus(workId: string, status: RemovalStatus | 'LIKE') {
+async function postStatus(workId: string, status: ReactionStatus) {
   await fetchJson('/api/reactions', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -46,88 +51,162 @@ async function postStatus(workId: string, status: RemovalStatus | 'LIKE') {
   })
 }
 
-export default function LikesLibrary({ current, archived, view }: Props) {
-  const [removed, setRemoved] = useState<Set<string>>(() => new Set())
+export default function LikesLibrary({ current, archived, seen, friendsByWork, view }: Props) {
+  const [active, setActive] = useState(current)
+  const [archive, setArchive] = useState(archived)
+  const [seenList, setSeenList] = useState(seen)
   const [toast, setToast] = useState<Toast | null>(null)
-  const [undoing, setUndoing] = useState(false)
+  const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<{ workId: string; bucket: LikeBucket } | null>(null)
 
-  // Auto-dismiss : la fenêtre d'undo se relance à chaque nouveau toast.
+  // Filtres / tri (côté client).
+  const [query, setQuery] = useState('')
+  const [section, setSection] = useState<'all' | 'theatre' | 'cinema'>('all')
+  const [bookableOnly, setBookableOnly] = useState(false)
+  const [sort, setSort] = useState<SortKey>('recent')
+
   useEffect(() => {
     if (!toast) return
     const id = setTimeout(() => setToast(null), UNDO_WINDOW_MS)
     return () => clearTimeout(id)
   }, [toast])
 
-  const hide = useCallback((workId: string) => {
-    setRemoved((prev) => {
-      const next = new Set(prev)
-      next.add(workId)
-      return next
-    })
-  }, [])
+  // Les setters useState sont stables → callbacks sans dépendances.
+  const setterFor = useCallback(
+    (bucket: SourceBucket) => (bucket === 'active' ? setActive : bucket === 'archived' ? setArchive : setSeenList),
+    [],
+  )
 
-  const unhide = useCallback((workId: string) => {
-    setRemoved((prev) => {
-      if (!prev.has(workId)) return prev
-      const next = new Set(prev)
-      next.delete(workId)
-      return next
-    })
-  }, [])
+  const removeFrom = useCallback(
+    (bucket: SourceBucket, workId: string) => {
+      setterFor(bucket)((prev) => prev.filter((i) => i.workId !== workId))
+    },
+    [setterFor],
+  )
 
-  const act = useCallback(
-    async (item: LikedItem, status: RemovalStatus) => {
+  const addTo = useCallback(
+    (bucket: SourceBucket, item: LikedItem) => {
+      setterFor(bucket)((prev) => (prev.some((i) => i.workId === item.workId) ? prev : [item, ...prev]))
+    },
+    [setterFor],
+  )
+
+  // Marquer vu : déplace une œuvre likée vers « Déjà vus ».
+  const markSeen = useCallback(
+    async (item: LikedItem, from: SourceBucket) => {
       setError(null)
-      // Update optimiste : la carte disparaît immédiatement (plus de router.refresh global).
-      hide(item.workId)
-      setToast({ workId: item.workId, title: titleOf(item), status })
+      setSelected(null)
+      removeFrom(from, item.workId)
+      addTo('seen', item)
+      setToast({ item, title: titleOf(item), message: 'marqué comme vu', from, undoStatus: 'LIKE' })
       try {
-        await postStatus(item.workId, status)
+        await postStatus(item.workId, 'SEEN')
       } catch {
-        // Rollback explicite : la carte revient, le toast disparaît.
-        unhide(item.workId)
+        removeFrom('seen', item.workId)
+        addTo(from, item)
         setToast(null)
         setError('Action non enregistrée. Réessaie.')
       }
     },
-    [hide, unhide],
+    [addTo, removeFrom],
+  )
+
+  // Retirer : sort l'œuvre de la bibliothèque.
+  const remove = useCallback(
+    async (item: LikedItem, from: SourceBucket) => {
+      setError(null)
+      setSelected(null)
+      removeFrom(from, item.workId)
+      const undoStatus = from === 'seen' ? 'SEEN' : 'LIKE'
+      setToast({ item, title: titleOf(item), message: 'retiré', from, undoStatus })
+      try {
+        await postStatus(item.workId, 'DISLIKE')
+      } catch {
+        addTo(from, item)
+        setToast(null)
+        setError('Action non enregistrée. Réessaie.')
+      }
+    },
+    [addTo, removeFrom],
   )
 
   const undo = useCallback(
-    async (workId: string) => {
-      if (undoing) return
-      setUndoing(true)
+    async (t: Toast) => {
+      if (busy) return
+      setBusy(true)
       setError(null)
-      unhide(workId)
+      // markSeen a pu déplacer l'item vers « Déjà vus » : on l'en retire puis on restaure.
+      removeFrom('seen', t.item.workId)
+      addTo(t.from, t.item)
       setToast(null)
       try {
-        await postStatus(workId, 'LIKE')
+        await postStatus(t.item.workId, t.undoStatus)
       } catch {
-        hide(workId)
         setError('Annulation impossible. Réessaie.')
       } finally {
-        setUndoing(false)
+        setBusy(false)
       }
     },
-    [hide, unhide, undoing],
+    [addTo, busy, removeFrom],
   )
 
-  const visibleCurrent = current.filter((item) => !removed.has(item.workId))
-  const visibleArchived = archived.filter((item) => !removed.has(item.workId))
-  const total = visibleCurrent.length + visibleArchived.length
+  const totalLikes = active.length + archive.length
+
+  // Liste de base selon l'onglet.
+  const baseItems = useMemo<{ items: LikedItem[]; bucket: LikeBucket }>(() => {
+    if (view === 'seen') return { items: seenList, bucket: 'seen' }
+    if (view === 'active') return { items: active, bucket: 'like' }
+    if (view === 'archived') return { items: archive, bucket: 'like' }
+    return { items: [...active, ...archive], bucket: 'like' }
+  }, [view, active, archive, seenList])
+
+  // Filtres + tri.
+  const items = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    let list = baseItems.items.filter((item) => {
+      const w = item.work
+      if (section !== 'all' && w?.section !== section) return false
+      if (bookableOnly && w?.availability !== 'InStock') return false
+      if (q) {
+        const hay = [w?.title, w?.venue, w?.director, w?.arrondissement].filter(Boolean).join(' ').toLowerCase()
+        if (!hay.includes(q)) return false
+      }
+      return true
+    })
+    if (sort === 'ending') {
+      list = [...list].sort((a, b) => {
+        const da = a.work?.endDate ? new Date(a.work.endDate).getTime() : Infinity
+        const db = b.work?.endDate ? new Date(b.work.endDate).getTime() : Infinity
+        return da - db
+      })
+    } else if (sort === 'price') {
+      list = [...list].sort((a, b) => (a.work?.priceMin ?? Infinity) - (b.work?.priceMin ?? Infinity))
+    }
+    return list
+  }, [baseItems, query, section, bookableOnly, sort])
+
+  const selectedItem = useMemo(() => {
+    if (!selected) return null
+    return (
+      active.find((i) => i.workId === selected.workId) ??
+      archive.find((i) => i.workId === selected.workId) ??
+      seenList.find((i) => i.workId === selected.workId) ??
+      null
+    )
+  }, [selected, active, archive, seenList])
 
   return (
     <>
       <PageHeader
         eyebrow="Bibliothèque"
         title="Mes likes"
-        description="Retrouve tes coups de coeur, trie-les entre les oeuvres encore a l'affiche et celles deja terminees, puis garde seulement ce qui merite de revenir dans ta file."
+        description="Ta shortlist de sorties : repère ce qui se termine bientôt, vérifie la dispo et réserve. Clique une carte pour le détail."
         meta={
           <>
-            <span className="chip">{total} like{total > 1 ? 's' : ''} au total</span>
-            <span className="chip">{visibleCurrent.length} en cours</span>
-            <span className="chip">{visibleArchived.length} archives</span>
+            <span className="chip">{totalLikes} à voir</span>
+            <span className="chip">{active.length} à l’affiche</span>
+            <span className="chip">{seenList.length} déjà vus</span>
           </>
         }
       >
@@ -135,14 +214,15 @@ export default function LikesLibrary({ current, archived, view }: Props) {
           ariaLabel="Filtrer les likes"
           value={view}
           items={[
-            { label: 'Tous', value: 'all', href: '/likes', count: total },
-            { label: 'À l’affiche', value: 'active', href: '/likes?view=active', count: visibleCurrent.length },
-            { label: 'Archivées', value: 'archived', href: '/likes?view=archived', count: visibleArchived.length },
+            { label: 'Tous', value: 'all', href: '/likes', count: totalLikes },
+            { label: 'À l’affiche', value: 'active', href: '/likes?view=active', count: active.length },
+            { label: 'Archivées', value: 'archived', href: '/likes?view=archived', count: archive.length },
+            { label: 'Déjà vus', value: 'seen', href: '/likes?view=seen', count: seenList.length },
           ]}
         />
       </PageHeader>
 
-      {total === 0 ? (
+      {totalLikes + seenList.length === 0 ? (
         <SurfaceCard>
           <div className="empty-state">
             <span className="chip">Bibliothèque vide</span>
@@ -153,29 +233,37 @@ export default function LikesLibrary({ current, archived, view }: Props) {
           </div>
         </SurfaceCard>
       ) : (
-        <div className="space-y-8">
-          {view !== 'archived' ? (
-            <LikesSection
-              title="À l’affiche"
-              description="Ces oeuvres sont encore en cours de programmation."
-              emptyLabel="Aucun like actuellement à l’affiche."
-              items={visibleCurrent}
-              tone="accent"
-              onAct={act}
-            />
-          ) : null}
+        <SurfaceCard className="space-y-4">
+          <Toolbar
+            query={query}
+            onQuery={setQuery}
+            section={section}
+            onSection={setSection}
+            bookableOnly={bookableOnly}
+            onBookable={setBookableOnly}
+            sort={sort}
+            onSort={setSort}
+          />
 
-          {view !== 'active' ? (
-            <LikesSection
-              title="Plus à l’affiche"
-              description="Retrouve ici les films et pièces dont la programmation est terminée."
-              emptyLabel="Aucun like archivé."
-              items={visibleArchived}
-              tone="muted"
-              onAct={act}
-            />
-          ) : null}
-        </div>
+          {items.length === 0 ? (
+            <div className="empty-state rounded-[var(--radius-lg)] border border-dashed border-[color:var(--color-border)] bg-white/50">
+              <strong>Rien ne correspond à ce filtre.</strong>
+            </div>
+          ) : (
+            <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {items.map((item) => (
+                <li key={item.workId}>
+                  <CompactLikeCard
+                    work={item.work}
+                    fallbackTitle={item.workId}
+                    friends={friendsByWork[item.workId] ?? []}
+                    onOpen={() => setSelected({ workId: item.workId, bucket: baseItems.bucket })}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </SurfaceCard>
       )}
 
       {error ? (
@@ -184,112 +272,116 @@ export default function LikesLibrary({ current, archived, view }: Props) {
         </p>
       ) : null}
 
-      <UndoToast toast={toast} undoing={undoing} onUndo={undo} onDismiss={() => setToast(null)} />
+      {selected && selectedItem ? (
+        <LikeDetailModal
+          work={selectedItem.work}
+          fallbackTitle={selectedItem.workId}
+          friends={friendsByWork[selectedItem.workId] ?? []}
+          bucket={selected.bucket}
+          onClose={() => setSelected(null)}
+          onSeen={() => markSeen(selectedItem, bucketOf(selectedItem, active, archive))}
+          onRemove={() => remove(selectedItem, selected.bucket === 'seen' ? 'seen' : bucketOf(selectedItem, active, archive))}
+        />
+      ) : null}
+
+      <UndoToast toast={toast} busy={busy} onUndo={undo} onDismiss={() => setToast(null)} />
     </>
   )
 }
 
-type LikesSectionProps = {
-  title: string
-  description: string
-  emptyLabel: string
-  items: LikedItem[]
-  tone: 'accent' | 'muted'
-  onAct: (item: LikedItem, status: RemovalStatus) => void
+// Détermine si une œuvre likée est dans la liste active ou archivée.
+function bucketOf(item: LikedItem, active: LikedItem[], archive: LikedItem[]): SourceBucket {
+  if (archive.some((i) => i.workId === item.workId)) return 'archived'
+  return 'active'
 }
 
-function LikesSection({ title, description, emptyLabel, items, tone, onAct }: LikesSectionProps) {
+function Toolbar({
+  query,
+  onQuery,
+  section,
+  onSection,
+  bookableOnly,
+  onBookable,
+  sort,
+  onSort,
+}: {
+  query: string
+  onQuery: (v: string) => void
+  section: 'all' | 'theatre' | 'cinema'
+  onSection: (v: 'all' | 'theatre' | 'cinema') => void
+  bookableOnly: boolean
+  onBookable: (v: boolean) => void
+  sort: SortKey
+  onSort: (v: SortKey) => void
+}) {
   return (
-    <SurfaceCard as="section" tone={tone} className="space-y-5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h2 className="text-2xl font-semibold tracking-[-0.03em]">{title}</h2>
-          <p className="text-sm leading-7 text-muted-foreground">{description}</p>
-        </div>
-        <span className="chip">{items.length} oeuvre{items.length > 1 ? 's' : ''}</span>
+    <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <input
+        type="search"
+        className="input lg:max-w-xs"
+        placeholder="Rechercher (titre, lieu, metteur en scène…)"
+        value={query}
+        onChange={(e) => onQuery(e.target.value)}
+        aria-label="Rechercher dans mes likes"
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <SegmentedControl
+          ariaLabel="Filtrer par type"
+          value={section}
+          onChange={(v) => onSection(v as 'all' | 'theatre' | 'cinema')}
+          items={[
+            { label: 'Tout', value: 'all' },
+            { label: 'Théâtre', value: 'theatre' },
+            { label: 'Cinéma', value: 'cinema' },
+          ]}
+        />
+        <label className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[color:var(--color-border)] bg-white/70 px-3 py-1.5 text-xs font-medium">
+          <input type="checkbox" checked={bookableOnly} onChange={(e) => onBookable(e.target.checked)} />
+          Réservable
+        </label>
+        <select
+          className="input w-auto py-1.5 text-sm"
+          value={sort}
+          onChange={(e) => onSort(e.target.value as SortKey)}
+          aria-label="Trier"
+        >
+          <option value="recent">Récents</option>
+          <option value="ending">Fin proche</option>
+          <option value="price">Prix croissant</option>
+        </select>
       </div>
-
-      {items.length === 0 ? (
-        <div className="empty-state rounded-[var(--radius-lg)] border border-dashed border-[color:var(--color-border)] bg-white/50">
-          <strong>{emptyLabel}</strong>
-        </div>
-      ) : (
-        <ul className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-          {items.map((item) => (
-            <li key={item.workId} className="h-full">
-              <WorkSummaryCard
-                work={item.work}
-                fallbackTitle={item.workId}
-                actions={
-                  <CardActions
-                    onSeen={() => onAct(item, 'SEEN')}
-                    onRemove={() => onAct(item, 'DISLIKE')}
-                  />
-                }
-              />
-            </li>
-          ))}
-        </ul>
-      )}
-    </SurfaceCard>
-  )
-}
-
-function CardActions({ onSeen, onRemove }: { onSeen: () => void; onRemove: () => void }) {
-  return (
-    <div className="mt-1 flex flex-wrap gap-2">
-      <button
-        type="button"
-        className="btn btn-secondary min-w-[6.5rem] px-3 py-2 text-sm"
-        onClick={onSeen}
-        title="Je l’ai vu — le retirer de mes likes"
-      >
-        Marquer vu
-      </button>
-      <button
-        type="button"
-        className="btn min-w-[6.5rem] border-[rgba(160,74,65,0.18)] bg-[rgba(249,236,233,0.7)] px-3 py-2 text-sm text-[color:var(--color-danger)]"
-        onClick={onRemove}
-        title="Je ne suis plus intéressé·e — le retirer de mes likes"
-      >
-        Retirer
-      </button>
     </div>
   )
 }
 
 function UndoToast({
   toast,
-  undoing,
+  busy,
   onUndo,
   onDismiss,
 }: {
   toast: Toast | null
-  undoing: boolean
-  onUndo: (workId: string) => void
+  busy: boolean
+  onUndo: (t: Toast) => void
   onDismiss: () => void
 }) {
   if (!toast) return null
-
-  const message =
-    toast.status === 'SEEN'
-      ? `« ${toast.title} » marqué comme vu, retiré de tes likes`
-      : `« ${toast.title} » retiré de tes likes`
-
   return (
     <div
       role="status"
       aria-live="polite"
-      className="fixed inset-x-0 bottom-6 z-50 mx-auto flex w-fit max-w-[90vw] items-center gap-4 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] px-5 py-3 shadow-[var(--shadow-lg)]"
+      className="fixed inset-x-0 bottom-6 z-[60] mx-auto flex w-fit max-w-[90vw] items-center gap-4 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] px-5 py-3 shadow-[var(--shadow-lg)]"
     >
-      <span className="text-sm font-medium text-[color:var(--color-text)]">{message}</span>
+      <span className="text-sm font-medium text-[color:var(--color-text)]">
+        « {toast.title} » {toast.message}
+      </span>
       <button
         type="button"
-        onClick={() => onUndo(toast.workId)}
-        disabled={undoing}
+        onClick={() => onUndo(toast)}
+        disabled={busy}
         className="text-sm font-semibold text-[color:var(--color-accent)] underline-offset-2 hover:underline disabled:opacity-50"
       >
-        {undoing ? '…' : 'Annuler'}
+        {busy ? '…' : 'Annuler'}
       </button>
       <button
         type="button"

--- a/app/src/features/works/ui/work-formatters.ts
+++ b/app/src/features/works/ui/work-formatters.ts
@@ -44,6 +44,23 @@ export function formatPriceRange(min: number | null, max: number | null) {
   return null
 }
 
+// Urgence : à combien de jours se termine la programmation. null si pas de date
+// ou échéance lointaine (> 21 j). `urgent` déclenche l'accent visuel.
+export function formatEndsIn(endDate: string | null, now: Date = new Date()): { label: string; urgent: boolean; days: number } | null {
+  if (!endDate) return null
+  const end = new Date(endDate)
+  if (Number.isNaN(end.getTime())) return null
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const endDay = new Date(end.getFullYear(), end.getMonth(), end.getDate())
+  const days = Math.round((endDay.getTime() - startOfToday.getTime()) / 86_400_000)
+  if (days < 0) return null
+  if (days === 0) return { label: 'Dernier jour', urgent: true, days }
+  if (days === 1) return { label: 'Se termine demain', urgent: true, days }
+  if (days <= 7) return { label: `Plus que ${days} jours`, urgent: true, days }
+  if (days <= 21) return { label: `Encore ${days} jours`, urgent: false, days }
+  return null
+}
+
 // Disponibilité billetterie (valeurs schema.org) → libellé + tonalité d'affichage.
 export type AvailabilityBadge = { label: string; tone: 'success' | 'danger' | 'warning' }
 

--- a/app/tests/likes-library.test.tsx
+++ b/app/tests/likes-library.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 vi.mock('next/image', () => ({
@@ -7,18 +7,15 @@ vi.mock('next/image', () => ({
 }))
 
 import LikesLibrary, { type LikedItem } from '@/features/reactions/ui/LikesLibrary'
+import type { WorkCardDto } from '@/features/works/dto'
 
-function makeItem(
-  id: string,
-  title: string,
-  credits?: { director?: string | null; cast?: string[]; section?: 'theatre' | 'cinema' },
-): LikedItem {
+function makeItem(id: string, title: string, over: Partial<WorkCardDto> = {}): LikedItem {
   return {
     workId: id,
     work: {
       id,
       title,
-      section: credits?.section ?? 'theatre',
+      section: 'theatre',
       imageUrl: null,
       category: null,
       venue: null,
@@ -29,102 +26,110 @@ function makeItem(
       durationMin: null,
       priceMin: null,
       priceMax: null,
-      director: credits?.director ?? null,
-      cast: credits?.cast ?? [],
+      director: null,
+      cast: [],
+      arrondissement: null,
+      country: null,
+      year: null,
+      availability: null,
+      currency: null,
       sourceUrl: null,
+      venueInfo: null,
+      ...over,
     },
   }
 }
 
-function jsonResponse(ok: boolean, status: string) {
-  return {
-    ok,
-    status: ok ? 200 : 500,
-    text: async () => JSON.stringify(ok ? { ok: true, reaction: { id: 'r', status } } : { ok: false, error: 'server_error' }),
-  } as Response
+function jsonOk(payload: unknown = { ok: true, reaction: { id: 'r', status: 'DISLIKE' } }) {
+  return { ok: true, status: 200, text: async () => JSON.stringify(payload) } as Response
+}
+
+async function openDetail(user: ReturnType<typeof userEvent.setup>, title: string) {
+  await user.click(screen.getByRole('button', { name: new RegExp(`Voir le détail de ${title}`) }))
+  return screen.getByRole('dialog')
 }
 
 describe('LikesLibrary', () => {
   beforeEach(() => {
     vi.mocked(fetch).mockReset()
-    vi.mocked(fetch).mockResolvedValue(jsonResponse(true, 'DISLIKE'))
+    vi.mocked(fetch).mockResolvedValue(jsonOk())
   })
 
-  it('« Retirer » sort la carte optimistiquement et poste DISLIKE (pas de router.refresh)', async () => {
+  it('ouvre le détail au clic et « Retirer » sort la carte optimistiquement (DISLIKE)', async () => {
     const user = userEvent.setup()
-    render(<LikesLibrary current={[makeItem('w1', 'Hamlet')]} archived={[]} view="all" />)
+    render(<LikesLibrary current={[makeItem('w1', 'Hamlet')]} archived={[]} seen={[]} friendsByWork={{}} view="all" />)
 
-    expect(screen.getByText('Hamlet')).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'Retirer' }))
+    const dialog = await openDetail(user, 'Hamlet')
+    await user.click(within(dialog).getByRole('button', { name: 'Retirer' }))
 
-    expect(screen.queryByText('Hamlet')).not.toBeInTheDocument()
     await waitFor(() =>
       expect(fetch).toHaveBeenCalledWith(
         '/api/reactions',
         expect.objectContaining({ method: 'POST', body: JSON.stringify({ workId: 'w1', status: 'DISLIKE' }) }),
       ),
     )
-    expect(screen.getByText(/retiré de tes likes/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Annuler' })).toBeInTheDocument()
-  })
-
-  it('« Marquer vu » poste SEEN avec un message explicite', async () => {
-    const user = userEvent.setup()
-    vi.mocked(fetch).mockResolvedValue(jsonResponse(true, 'SEEN'))
-    render(<LikesLibrary current={[makeItem('w1', 'Hamlet')]} archived={[]} view="all" />)
-
-    await user.click(screen.getByRole('button', { name: 'Marquer vu' }))
-
     expect(screen.queryByText('Hamlet')).not.toBeInTheDocument()
-    await waitFor(() =>
-      expect(fetch).toHaveBeenCalledWith(
-        '/api/reactions',
-        expect.objectContaining({ method: 'POST', body: JSON.stringify({ workId: 'w1', status: 'SEEN' }) }),
-      ),
-    )
-    expect(screen.getByText(/marqué comme vu/i)).toBeInTheDocument()
-  })
+    expect(screen.getByRole('button', { name: 'Annuler' })).toBeInTheDocument()
+  }, 15000)
 
   it('« Annuler » restaure la carte et poste LIKE', async () => {
     const user = userEvent.setup()
-    render(<LikesLibrary current={[makeItem('w1', 'Hamlet')]} archived={[]} view="all" />)
+    render(<LikesLibrary current={[makeItem('w1', 'Hamlet')]} archived={[]} seen={[]} friendsByWork={{}} view="all" />)
 
-    await user.click(screen.getByRole('button', { name: 'Retirer' }))
-    await screen.findByRole('button', { name: 'Annuler' })
+    const dialog = await openDetail(user, 'Hamlet')
+    await user.click(within(dialog).getByRole('button', { name: 'Retirer' }))
+    await user.click(await screen.findByRole('button', { name: 'Annuler' }))
 
-    vi.mocked(fetch).mockResolvedValue(jsonResponse(true, 'LIKE'))
-    await user.click(screen.getByRole('button', { name: 'Annuler' }))
-
-    await screen.findByText('Hamlet')
+    await screen.findByRole('button', { name: /Voir le détail de Hamlet/ })
     expect(fetch).toHaveBeenLastCalledWith(
       '/api/reactions',
-      expect.objectContaining({ method: 'POST', body: JSON.stringify({ workId: 'w1', status: 'LIKE' }) }),
+      expect.objectContaining({ body: JSON.stringify({ workId: 'w1', status: 'LIKE' }) }),
     )
-  })
+  }, 15000)
 
-  it('affiche le réalisateur et le casting sur la carte', () => {
+  it('« Marquer vu » poste SEEN et déplace l’œuvre hors des likes', async () => {
+    const user = userEvent.setup()
+    render(<LikesLibrary current={[makeItem('w1', 'Hamlet')]} archived={[]} seen={[]} friendsByWork={{}} view="active" />)
+
+    const dialog = await openDetail(user, 'Hamlet')
+    await user.click(within(dialog).getByRole('button', { name: 'Marquer vu' }))
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/reactions',
+        expect.objectContaining({ body: JSON.stringify({ workId: 'w1', status: 'SEEN' }) }),
+      ),
+    )
+    expect(screen.queryByRole('button', { name: /Voir le détail de Hamlet/ })).not.toBeInTheDocument()
+  }, 15000)
+
+  it('la recherche filtre les cartes', async () => {
+    const user = userEvent.setup()
     render(
       <LikesLibrary
-        current={[makeItem('w1', 'Voyage au bout de l’enfer', { section: 'cinema', director: 'Michael Cimino', cast: ['Robert De Niro', 'Christopher Walken'] })]}
+        current={[makeItem('w1', 'Hamlet'), makeItem('w2', 'Macbeth')]}
         archived={[]}
+        seen={[]}
+        friendsByWork={{}}
         view="all"
       />,
     )
 
-    expect(screen.getByText('Michael Cimino')).toBeInTheDocument()
-    expect(screen.getByText('Robert De Niro, Christopher Walken')).toBeInTheDocument()
-    expect(screen.getByText(/^De$/)).toBeInTheDocument()
-  })
+    await user.type(screen.getByLabelText('Rechercher dans mes likes'), 'mac')
+    expect(screen.queryByRole('button', { name: /Voir le détail de Hamlet/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Voir le détail de Macbeth/ })).toBeInTheDocument()
+  }, 15000)
 
-  it('rollback : si le POST échoue, la carte revient avec un message d’erreur', async () => {
-    const user = userEvent.setup()
-    vi.mocked(fetch).mockResolvedValue(jsonResponse(false, 'DISLIKE'))
-    render(<LikesLibrary current={[makeItem('w1', 'Hamlet')]} archived={[]} view="all" />)
-
-    await user.click(screen.getByRole('button', { name: 'Retirer' }))
-
-    await screen.findByText('Hamlet')
-    expect(screen.getByText(/non enregistrée/i)).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Annuler' })).not.toBeInTheDocument()
+  it('affiche le badge « amis qui aiment aussi »', () => {
+    render(
+      <LikesLibrary
+        current={[makeItem('w1', 'Hamlet')]}
+        archived={[]}
+        seen={[]}
+        friendsByWork={{ w1: [{ id: 'f1', email: 'lea@example.com' }] }}
+        view="all"
+      />,
+    )
+    expect(screen.getByText('LE')).toBeInTheDocument() // initiales de lea@
   })
 })

--- a/app/tests/likes-page.test.tsx
+++ b/app/tests/likes-page.test.tsx
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
-const { requireSessionUserMock, listLikedWorksMock, redirectMock } = vi.hoisted(() => ({
+const { requireSessionUserMock, listLibraryWorksMock, friendsWhoLikedMock, redirectMock } = vi.hoisted(() => ({
   requireSessionUserMock: vi.fn(),
-  listLikedWorksMock: vi.fn(),
+  listLibraryWorksMock: vi.fn(),
+  friendsWhoLikedMock: vi.fn(),
   redirectMock: vi.fn(),
 }))
 
@@ -20,73 +21,79 @@ vi.mock('@/features/auth/server/session', () => ({
 }))
 
 vi.mock('@/features/reactions/server/queries', () => ({
-  listLikedWorks: listLikedWorksMock,
+  listLibraryWorks: listLibraryWorksMock,
+  friendsWhoLiked: friendsWhoLikedMock,
 }))
 
 import LikesPage from '@/app/likes/page'
+
+function work(id: string, title: string, endDate: string | null) {
+  return {
+    id,
+    title,
+    section: 'theatre',
+    imageUrl: null,
+    category: null,
+    venue: null,
+    address: null,
+    description: null,
+    startDate: null,
+    endDate,
+    durationMin: null,
+    priceMin: null,
+    priceMax: null,
+    director: null,
+    cast: [],
+    arrondissement: null,
+    country: null,
+    year: null,
+    availability: null,
+    currency: null,
+    sourceUrl: 'https://www.offi.fr/x',
+    venueInfo: null,
+  }
+}
 
 describe('/likes page', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-12T10:00:00.000Z'))
+    requireSessionUserMock.mockResolvedValue({ id: 'user-1', email: 'me@example.com' })
+    friendsWhoLikedMock.mockResolvedValue({})
   })
 
   afterEach(() => {
     vi.useRealTimers()
   })
 
-  it('splits current likes from works that are no longer showing', async () => {
-    requireSessionUserMock.mockResolvedValue({ id: 'user-1', email: 'me@example.com' })
-    listLikedWorksMock.mockResolvedValue([
-      {
-        workId: 'work-current',
-        work: {
-          id: 'work-current',
-          title: 'Hamlet',
-          section: 'theatre',
-          imageUrl: null,
-          category: null,
-          venue: null,
-          address: null,
-          description: null,
-          startDate: '2026-03-01T00:00:00.000Z',
-          endDate: '2026-03-30T00:00:00.000Z',
-          durationMin: null,
-          priceMin: null,
-          priceMax: null,
-          sourceUrl: 'https://www.offi.fr/hamlet',
-        },
-      },
-      {
-        workId: 'work-archived',
-        work: {
-          id: 'work-archived',
-          title: 'La Lecon',
-          section: 'theatre',
-          imageUrl: null,
-          category: null,
-          venue: null,
-          address: null,
-          description: null,
-          startDate: '2026-02-01T00:00:00.000Z',
-          endDate: '2026-03-11T00:00:00.000Z',
-          durationMin: null,
-          priceMin: null,
-          priceMax: null,
-          sourceUrl: 'https://www.offi.fr/la-lecon',
-        },
-      },
-    ])
+  it('affiche les likes courants et archivés dans l’onglet « Tous »', async () => {
+    listLibraryWorksMock.mockResolvedValue({
+      likes: [
+        { workId: 'work-current', work: work('work-current', 'Hamlet', '2026-03-30T00:00:00.000Z') },
+        { workId: 'work-archived', work: work('work-archived', 'La Lecon', '2026-03-11T00:00:00.000Z') },
+      ],
+      seen: [],
+    })
 
     render(await LikesPage())
 
-    const currentSection = screen.getByRole('heading', { name: 'À l’affiche' }).closest('section')
-    const archivedSection = screen.getByRole('heading', { name: 'Plus à l’affiche' }).closest('section')
+    expect(screen.getByRole('button', { name: /Voir le détail de Hamlet/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Voir le détail de La Lecon/ })).toBeInTheDocument()
+    expect(friendsWhoLikedMock).toHaveBeenCalledWith('user-1', ['work-current', 'work-archived'])
+  })
 
-    expect(currentSection).not.toBeNull()
-    expect(archivedSection).not.toBeNull()
-    expect(within(currentSection as HTMLElement).getByText('Hamlet')).toBeInTheDocument()
-    expect(within(archivedSection as HTMLElement).getByText('La Lecon')).toBeInTheDocument()
-    expect(within(currentSection as HTMLElement).queryByText('La Lecon')).not.toBeInTheDocument()
+  it('n’affiche que les œuvres à l’affiche en vue active', async () => {
+    listLibraryWorksMock.mockResolvedValue({
+      likes: [
+        { workId: 'work-current', work: work('work-current', 'Hamlet', '2026-03-30T00:00:00.000Z') },
+        { workId: 'work-archived', work: work('work-archived', 'La Lecon', '2026-03-11T00:00:00.000Z') },
+      ],
+      seen: [],
+    })
+
+    render(await LikesPage({ searchParams: Promise.resolve({ view: 'active' }) }))
+
+    expect(screen.getByRole('button', { name: /Voir le détail de Hamlet/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Voir le détail de La Lecon/ })).not.toBeInTheDocument()
   })
 })

--- a/app/tests/work-formatters.test.ts
+++ b/app/tests/work-formatters.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { formatAvailability, formatEndsIn } from '@/features/works/ui/work-formatters'
+
+const now = new Date('2026-06-09T10:00:00.000Z')
+
+describe('formatEndsIn', () => {
+  it('aujourd’hui = dernier jour (urgent)', () => {
+    expect(formatEndsIn('2026-06-09T20:00:00.000Z', now)).toMatchObject({ label: 'Dernier jour', urgent: true })
+  })
+
+  it('demain (urgent)', () => {
+    expect(formatEndsIn('2026-06-10T00:00:00.000Z', now)).toMatchObject({ label: 'Se termine demain', urgent: true })
+  })
+
+  it('dans 5 jours = urgent', () => {
+    expect(formatEndsIn('2026-06-14T00:00:00.000Z', now)).toMatchObject({ label: 'Plus que 5 jours', urgent: true })
+  })
+
+  it('dans 15 jours = non urgent', () => {
+    expect(formatEndsIn('2026-06-24T00:00:00.000Z', now)).toMatchObject({ urgent: false })
+  })
+
+  it('échéance lointaine ou passée ou absente = null', () => {
+    expect(formatEndsIn('2026-09-01T00:00:00.000Z', now)).toBeNull()
+    expect(formatEndsIn('2026-06-01T00:00:00.000Z', now)).toBeNull()
+    expect(formatEndsIn(null, now)).toBeNull()
+  })
+})
+
+describe('formatAvailability', () => {
+  it('InStock → succès', () => {
+    expect(formatAvailability('InStock')).toMatchObject({ label: 'Billets dispo', tone: 'success' })
+  })
+  it('SoldOut → danger', () => {
+    expect(formatAvailability('SoldOut')).toMatchObject({ label: 'Complet', tone: 'danger' })
+  })
+  it('inconnu → null', () => {
+    expect(formatAvailability('Bogus')).toBeNull()
+    expect(formatAvailability(null)).toBeNull()
+  })
+})


### PR DESCRIPTION
Transforme /likes d une liste passive en **outil de décision/réservation**.

## Ce qui change
- **Cartes compactes cliquables** (vignette + titre + badges) ; le **détail s ouvre dans une modale** (réutilise `WorkSummaryCard`) → plus de détail encombrant en vue liste.
- **Urgence** (#1) : badge « se termine dans X jours » + tri « Fin proche ».
- **Réserver + dispo** (#2) : CTA proéminent + badge **Billets dispo / Complet** + prix + lien **itinéraire**.
- **Filtres/tri/recherche** (#4) : théâtre/ciné, « réservable », tri (récents/fin proche/prix), recherche.
- **Amis qui aiment aussi** (#5) : avatars/initiales sur la carte + dans la modale.
- **Onglet « Déjà vus »** (#6) : les œuvres marquées vues vont dans un historique (au lieu de disparaître) ; déplacement optimiste likes→vus + undo.

## Technique
- `listLibraryWorks` (likes + vus en 1 requête) + `friendsWhoLiked`. Nouveau `formatEndsIn`.
- Nouveaux composants `CompactLikeCard`, `LikeDetailModal` ; `LikesLibrary` réécrit.
- Tests : likes-library (5), likes-page (2), work-formatters (8). **101 tests** verts, lint/typecheck OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)