### PR TITLE
fix(ci): activer pnpm@10 dans offi-refresh

### DIFF
--- a/.github/workflows/offi-refresh.yml
+++ b/.github/workflows/offi-refresh.yml
@@ -47,6 +47,10 @@ jobs:
           node-version: 22
           package-manager-cache: false
       - run: corepack enable
+      # Le pipeline lance `pnpm --dir app` depuis la racine (sans packageManager) :
+      # on active globalement la version épinglée par app/package.json (pnpm@10),
+      # sinon pnpm 11 par défaut refuse le projet (version mismatch).
+      - run: corepack prepare pnpm@10.0.0 --activate
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
2e cause du run cron : le pipeline lance `pnpm --dir app` depuis la racine où corepack active pnpm 11, qui refuse le projet épinglé `pnpm@10.0.0`. On active explicitement pnpm@10. (Scrape + Node 22 OK désormais.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)