### PR TITLE
fix(scraper): capter la synopsis théâtre (itemprop=description)

### DIFF
--- a/app/scripts/backfill-descriptions.ts
+++ b/app/scripts/backfill-descriptions.ts
@@ -1,0 +1,67 @@
+// Backfill one-off : remplit Work.description (surtout théâtre, ~1% couvert) depuis
+// la synopsis itemprop="description" d'offi. Les nouveaux scrapes la captent désormais.
+//
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/backfill-descriptions.ts [limit]
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { prisma } from '@/server/db'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const scraperDir = path.resolve(here, '../../scraper')
+const PY = path.join(scraperDir, '.venv/bin/python')
+const CLI = path.join(scraperDir, 'extract_credits_cli.py')
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+
+const limit = Number(process.argv[2] ?? 40)
+
+function extractDescription(html: string): string | null {
+  const res = spawnSync(PY, [CLI], {
+    input: html,
+    encoding: 'utf-8',
+    cwd: scraperDir,
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 10_000,
+    killSignal: 'SIGKILL',
+  })
+  if (res.status !== 0 || !res.stdout) return null
+  try {
+    return JSON.parse(res.stdout).description ?? null
+  } catch {
+    return null
+  }
+}
+
+async function main() {
+  const works = await prisma.work.findMany({
+    where: { description: null },
+    select: { id: true, sourceUrl: true },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  let updated = 0
+  for (const work of works) {
+    try {
+      const response = await fetch(work.sourceUrl, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(15_000) })
+      if (!response.ok) continue
+      const description = extractDescription(await response.text())
+      if (description) {
+        await prisma.work.update({ where: { id: work.id }, data: { description } })
+        updated += 1
+      }
+      await new Promise((resolve) => setTimeout(resolve, 350))
+    } catch {
+      // on saute les fiches en erreur
+    }
+  }
+
+  console.log(JSON.stringify({ scanned: works.length, updated }))
+}
+
+main()
+  .catch((error) => {
+    console.error('[backfill-descriptions]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/scraper/extract_credits_cli.py
+++ b/scraper/extract_credits_cli.py
@@ -19,6 +19,7 @@ def main() -> None:
     country, year = parsers.extract_cinema_meta(soup)
     arrondissement = parsers.extract_arrondissement(soup)
     offers = parsers.extract_offers(soup)
+    description = parsers.extract_description(soup)
     print(
         json.dumps(
             {
@@ -31,6 +32,7 @@ def main() -> None:
                 "currency": offers["currency"],
                 "price_min": offers["price_min"],
                 "price_max": offers["price_max"],
+                "description": description,
             },
             ensure_ascii=False,
         )

--- a/scraper/offi_scraper.py
+++ b/scraper/offi_scraper.py
@@ -697,26 +697,9 @@ class OffiScraper:
         return self._iso_from_any(text)
 
     def _extract_description(self, soup: BeautifulSoup) -> Optional[str]:
-        desc_keywords = ["présentation", "résumé", "synopsis", "à propos"]
-        for heading in soup.find_all(["h2", "h3", "h4"]):
-            ht = self._extract_text(heading).lower()
-            if any(k in ht for k in desc_keywords):
-                parts = []
-                for sib in heading.find_next_siblings():
-                    if sib.name in ["h2", "h3", "h4"]:
-                        break
-                    if sib.name in ["p", "div", "section"]:
-                        text = self._extract_text(sib)
-                        if text and len(text) > 10:
-                            parts.append(text)
-                if parts:
-                    return " ".join(parts)
-
-        meta_desc = soup.find("meta", attrs={"name": "description"})
-        if meta_desc and meta_desc.get("content"):
-            return meta_desc["content"].strip()
-
-        return None
+        # Délègue au parser pur : priorité au synopsis itemprop="description"
+        # (présent côté théâtre comme cinéma), sinon section dédiée, sinon meta.
+        return parsers.extract_description(soup)
 
     def _extract_cinema_category(self, soup: BeautifulSoup) -> Optional[str]:
         for raw in self._jsonld_blobs(soup):

--- a/scraper/parsers.py
+++ b/scraper/parsers.py
@@ -392,3 +392,42 @@ def extract_venue(soup, source_url: str, kind: str) -> Optional[dict]:
         "image": image,
         "source_url": source_url,
     }
+
+
+# --- Description / synopsis ------------------------------------------------------
+# Priorité au microdata itemprop="description" (synopsis propre, présent côté
+# théâtre ET cinéma), puis section "Présentation/Résumé/Synopsis", et en dernier
+# recours la meta name=description (souvent promotionnelle « Réservez vos billets… »).
+_DESC_HEADINGS = ("présentation", "presentation", "résumé", "resume", "synopsis", "à propos", "a propos")
+
+
+def _clean_text(value: str) -> str:
+    return re.sub(r"\s+", " ", value or "").strip()
+
+
+def extract_description(soup) -> Optional[str]:
+    el = soup.select_one('[itemprop="description"]')
+    if el:
+        text = _clean_text(el.get("content") or el.get_text(" ", strip=True))
+        if len(text) > 20:
+            return text
+
+    for heading in soup.find_all(["h2", "h3", "h4"]):
+        ht = heading.get_text(" ", strip=True).lower()
+        if any(k in ht for k in _DESC_HEADINGS):
+            parts: list[str] = []
+            for sib in heading.find_next_siblings():
+                if getattr(sib, "name", None) in ("h2", "h3", "h4"):
+                    break
+                if getattr(sib, "name", None) in ("p", "div", "section"):
+                    text = _clean_text(sib.get_text(" ", strip=True))
+                    if len(text) > 10:
+                        parts.append(text)
+            if parts:
+                return " ".join(parts)
+
+    meta_desc = soup.find("meta", attrs={"name": "description"})
+    if meta_desc and meta_desc.get("content"):
+        return _clean_text(meta_desc["content"])
+
+    return None

--- a/scraper/tests/test_parsers.py
+++ b/scraper/tests/test_parsers.py
@@ -227,5 +227,31 @@ class VenueTests(unittest.TestCase):
         self.assertIsNone(parsers.extract_venue(_soup("<div>no h1</div>"), "https://www.offi.fr/cinema/x-1.html", "cinema"))
 
 
+class ExtractDescriptionTests(unittest.TestCase):
+    def test_prefers_itemprop_over_promo_meta(self):
+        html = (
+            '<meta name="description" content="Réservez vos billets ✓ pour X • Du 5 juin">'
+            '<div itemprop="description">Mathurin Bolze réinvente sur scène un spectacle acrobatique et magnétique.</div>'
+        )
+        self.assertEqual(
+            parsers.extract_description(_soup(html)),
+            'Mathurin Bolze réinvente sur scène un spectacle acrobatique et magnétique.',
+        )
+
+    def test_section_heading_fallback(self):
+        html = '<h2>Présentation</h2><p>Une comédie baroque pleine de rebondissements et de musique.</p>'
+        self.assertEqual(
+            parsers.extract_description(_soup(html)),
+            'Une comédie baroque pleine de rebondissements et de musique.',
+        )
+
+    def test_meta_last_resort(self):
+        html = '<meta name="description" content="Description de repli quand rien d autre.">'
+        self.assertEqual(parsers.extract_description(_soup(html)), 'Description de repli quand rien d autre.')
+
+    def test_none_when_empty(self):
+        self.assertIsNone(parsers.extract_description(_soup('<div>rien</div>')))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Descriptions théâtre à 1%** (16/1957) vs 100% ciné. La synopsis existe pourtant (`itemprop="description"`) mais le parser cherchait une section « Présentation » sinon retombait sur la **meta promotionnelle** (« Réservez vos billets… »).

- `parsers.extract_description` priorise **itemprop=description** (synopsis propre, théâtre + ciné), puis section dédiée, puis meta en dernier recours. Le scraper délègue.
- `extract_credits_cli` renvoie `description` ; `scripts/backfill-descriptions.ts` (backfill théâtre en cours).
- **+4 tests → 45 scraper**, sanity-check live OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)