### PR TITLE
fix(ingest): tolérer les lignes invalides (ne plus tout abandonner)

### DIFF
--- a/app/src/features/offi-import/schemas.ts
+++ b/app/src/features/offi-import/schemas.ts
@@ -54,8 +54,14 @@ const nullableYear = z.preprocess(
 )
 
 const nullableMoney = z.preprocess(
-  (value) => (value === undefined || value === null || value === '' ? null : value),
-  z.number().nonnegative().max(500).nullable(),
+  (value) => {
+    if (value === undefined || value === null || value === '') return null
+    // Prix aberrant (artefact de parsing, ex. 1170) → on ignore le prix plutôt
+    // que d'invalider toute l'œuvre. Plafond relevé à 1000 pour les places premium.
+    if (typeof value === 'number' && (value < 0 || value > 1000)) return null
+    return value
+  },
+  z.number().nonnegative().max(1000).nullable(),
 )
 
 export const offiWorkSchema = z

--- a/app/src/features/offi-import/server/ingest.ts
+++ b/app/src/features/offi-import/server/ingest.ts
@@ -13,14 +13,27 @@ export async function readOffiFile(file: string) {
   })
 
   let lineNumber = 0
+  let skipped = 0
   for await (const rawLine of rl) {
     lineNumber += 1
     const line = rawLine.trim()
     if (!line) continue
 
-    const record = parseOffiJsonLine(line, lineNumber)
+    // Tolérant : une ligne invalide (ou en doublon) est ignorée et journalisée,
+    // sans interrompre l'ingestion entière (un job nocturne ne doit pas mourir
+    // pour un enregistrement aberrant parmi des milliers).
+    let record: OffiWorkRecord
+    try {
+      record = parseOffiJsonLine(line, lineNumber)
+    } catch (error) {
+      skipped += 1
+      console.warn(`[ingest:offi] ${error instanceof Error ? error.message : `Line ${lineNumber}: invalid`} — ignorée`)
+      continue
+    }
+
     if (seenUrls.has(record.url)) {
-      throw new Error(`Line ${lineNumber}: duplicate url ${record.url}`)
+      skipped += 1
+      continue
     }
 
     seenUrls.add(record.url)
@@ -29,6 +42,10 @@ export async function readOffiFile(file: string) {
 
   if (records.length === 0) {
     throw new Error(`No records found in ${file}`)
+  }
+
+  if (skipped > 0) {
+    console.warn(`[ingest:offi] ${skipped} ligne(s) ignorée(s) sur ${lineNumber}`)
   }
 
   return records

--- a/app/tests/offi.test.ts
+++ b/app/tests/offi.test.ts
@@ -118,6 +118,23 @@ describe('Offi ingestion helpers', () => {
     expect(update).toHaveProperty('year', 1978)
   })
 
+  it('ignore un prix aberrant (>1000) sans rejeter l’œuvre', () => {
+    const record = parseOffiJsonLine(
+      JSON.stringify({
+        url: 'https://www.offi.fr/theatre/x-1/show-2.html',
+        title: 'Spectacle',
+        section: 'theatre',
+        price_min_eur: 20,
+        price_max_eur: 1170,
+        description: 'desc',
+        date_start: '2026-03-12',
+      }),
+      604,
+    )
+    expect(record.price_min_eur).toBe(20)
+    expect(record.price_max_eur).toBeNull() // aberrant → ignoré, œuvre conservée
+  })
+
   it('rejette une année hors plage', () => {
     expect(() =>
       parseOffiJsonLine(


### PR DESCRIPTION
**3e cause d échec du cron** : un prix aberrant (1170, artefact de parsing) faisait échouer `parseOffiJsonLine` → **toute l ingestion s arrêtait** (`Line 604`). Un job nocturne ne doit pas mourir pour 1 enregistrement parmi des milliers.

- `readOffiFile` : ligne invalide/doublon **ignorée + journalisée**, on continue.
- `nullableMoney` : prix hors plage (>1000 ou <0) ramené à **null** plutôt que rejeter l œuvre ; plafond 500→1000 (places premium).
- Test : prix 1170 → `price_max_eur` null, œuvre conservée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)