### PR TITLE
fix(images): loader offi custom (bypass optimiseur Vercel) + fallback onError

### DIFF
--- a/app/image-loader.ts
+++ b/app/image-loader.ts
@@ -1,0 +1,14 @@
+// Loader d'images custom (next/image). Pour les images offi (files.offi.fr/.../images/<n>/…),
+// on pioche directement la taille hébergée par offi la plus adaptée → l'image est servie
+// DIRECTEMENT par offi, sans passer par l'optimiseur Vercel (pas de quota, pas de point
+// de panne). offi n'expose que ces 3 tailles (les autres redirigent vers une page d'erreur).
+const OFFI_SIZES = [120, 200, 1000]
+
+export default function offiImageLoader({ src, width }: { src: string; width: number; quality?: number }): string {
+  if (!src.includes('files.offi.fr') || !/\/images\/\d+\//.test(src)) {
+    // Hors offi : on sert l'URL telle quelle (le loader custom remplace l'optimiseur).
+    return src
+  }
+  const size = OFFI_SIZES.find((s) => s >= width) ?? OFFI_SIZES[OFFI_SIZES.length - 1]
+  return src.replace(/\/images\/\d+\//, `/images/${size}/`)
+}

--- a/app/next-env.d.ts
+++ b/app/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -34,6 +34,11 @@ const securityHeaders = [
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
+    // Loader custom : les images offi sont servies directement par offi (à la bonne
+    // taille hébergée), sans passer par l'optimiseur Vercel (évite le quota d'Image
+    // Optimization qui cassait les images en preview/prod).
+    loader: 'custom',
+    loaderFile: './image-loader.ts',
     remotePatterns: [
       { protocol: 'https', hostname: 'files.offi.fr' },
       { protocol: 'https', hostname: 'images.offi.fr' },

--- a/app/src/features/reactions/ui/CompactLikeCard.tsx
+++ b/app/src/features/reactions/ui/CompactLikeCard.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import Image from 'next/image'
 import type { FriendSummaryDto } from '@/features/friendships/dto'
 import type { WorkCardDto } from '@/features/works/dto'
+import WorkImage from '@/features/works/ui/WorkImage'
 import { formatAvailability, formatEndsIn, formatPriceRange } from '@/features/works/ui/work-formatters'
 
 function initials(email: string) {
@@ -37,11 +37,13 @@ export default function CompactLikeCard({ work, fallbackTitle, friends, onOpen }
       aria-label={`Voir le détail de ${title}`}
     >
       <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-[var(--radius-md)] bg-muted">
-        {work?.imageUrl ? (
-          <Image src={work.imageUrl} alt="" fill sizes="80px" className="object-cover" />
-        ) : (
-          <div className="flex h-full items-center justify-center text-[0.65rem] text-muted-foreground">—</div>
-        )}
+        <WorkImage
+          src={work?.imageUrl}
+          alt=""
+          sizes="80px"
+          className="object-cover"
+          fallback={<div className="flex h-full items-center justify-center text-[0.65rem] text-muted-foreground">—</div>}
+        />
       </div>
 
       <div className="flex min-w-0 flex-1 flex-col gap-1 py-0.5 pr-1">

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image'
 import { splitGenres } from '@/features/works/category'
+import WorkImage from '@/features/works/ui/WorkImage'
 import type { WorkCardDto } from '@/features/works/dto'
 import ExpandableDescription from '@/features/works/ui/ExpandableDescription'
 import { formatAvailability, formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
@@ -36,20 +36,18 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
       aria-describedby={`work-${work.id}-title`}
     >
       <div className="relative min-h-[14rem] flex-1 overflow-hidden rounded-[var(--radius-xl)] bg-muted">
-        {work.imageUrl ? (
-          <Image
-            src={work.imageUrl}
-            alt={work.title}
-            fill
-            sizes="(max-width: 768px) 100vw, 480px"
-            className="object-cover"
-            priority
-          />
-        ) : (
-          <div className="flex h-full items-center justify-center bg-[radial-gradient(circle_at_top,#fff3,transparent_55%)] text-sm text-muted-foreground">
-            Aucune image
-          </div>
-        )}
+        <WorkImage
+          src={work.imageUrl}
+          alt={work.title}
+          sizes="(max-width: 768px) 100vw, 480px"
+          className="object-cover"
+          priority
+          fallback={
+            <div className="flex h-full items-center justify-center bg-[radial-gradient(circle_at_top,#fff3,transparent_55%)] text-sm text-muted-foreground">
+              Aucune image
+            </div>
+          }
+        />
 
         <span className="absolute right-3 top-3 rounded-full border border-white/35 bg-black/35 px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-white backdrop-blur-sm">
           {sectionLabel}

--- a/app/src/features/works/ui/WorkImage.tsx
+++ b/app/src/features/works/ui/WorkImage.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import Image from 'next/image'
+import { useState, type ReactNode } from 'react'
+
+type WorkImageProps = {
+  src: string | null | undefined
+  alt: string
+  sizes: string
+  className?: string
+  priority?: boolean
+  // Affiché quand il n'y a pas d'image OU si le chargement échoue (au lieu d'une icône cassée).
+  fallback: ReactNode
+}
+
+// Image d'œuvre avec repli gracieux : si la source est absente ou échoue à charger,
+// on rend le placeholder fourni plutôt que l'icône d'image cassée du navigateur.
+export default function WorkImage({ src, alt, sizes, className, priority, fallback }: WorkImageProps) {
+  const [failed, setFailed] = useState(false)
+  if (!src || failed) return <>{fallback}</>
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      fill
+      sizes={sizes}
+      className={className}
+      priority={priority}
+      onError={() => setFailed(true)}
+    />
+  )
+}

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
-import Image from 'next/image'
 import type { WorkCardDto } from '@/features/works/dto'
 import BadgeCategory from '@/features/works/ui/BadgeCategory'
+import WorkImage from '@/features/works/ui/WorkImage'
 import { formatDateRange, formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
 import { cn } from '@/shared/lib/cn'
 import SurfaceCard from '@/shared/ui/SurfaceCard'
@@ -30,17 +30,15 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
   return (
     <SurfaceCard className={cn('flex h-full flex-col overflow-hidden p-0', className)} tone="muted">
       <div className="relative h-48 w-full overflow-hidden bg-muted">
-        {work?.imageUrl ? (
-          <Image
-            src={work.imageUrl}
-            alt={title}
-            fill
-            sizes="(max-width: 768px) 100vw, 420px"
-            className="object-cover"
-          />
-        ) : (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Pas d&apos;image</div>
-        )}
+        <WorkImage
+          src={work?.imageUrl}
+          alt={title}
+          sizes="(max-width: 768px) 100vw, 420px"
+          className="object-cover"
+          fallback={
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Pas d&apos;image</div>
+          }
+        />
 
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/40 to-transparent" />
 

--- a/app/tests/image-loader.test.ts
+++ b/app/tests/image-loader.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import offiImageLoader from '../image-loader'
+
+const OFFI = 'https://files.offi.fr/evenement/105426/images/1000/abc.jpg'
+
+describe('offiImageLoader', () => {
+  it('mappe vers la taille offi 120 pour une vignette', () => {
+    expect(offiImageLoader({ src: OFFI, width: 80 })).toBe(
+      'https://files.offi.fr/evenement/105426/images/120/abc.jpg',
+    )
+  })
+
+  it('mappe vers 200 pour une largeur intermédiaire', () => {
+    expect(offiImageLoader({ src: OFFI, width: 160 })).toContain('/images/200/')
+  })
+
+  it('mappe vers 1000 pour une grande largeur', () => {
+    expect(offiImageLoader({ src: OFFI, width: 480 })).toContain('/images/1000/')
+  })
+
+  it('réécrit aussi une source déjà en 120 vers la bonne taille', () => {
+    const small = 'https://files.offi.fr/lieu/3113/images/120/x.jpg'
+    expect(offiImageLoader({ src: small, width: 480 })).toContain('/images/1000/')
+  })
+
+  it('laisse les URLs non-offi inchangées', () => {
+    expect(offiImageLoader({ src: 'https://example.com/x.png', width: 200 })).toBe('https://example.com/x.png')
+  })
+})


### PR DESCRIPTION
## Diagnostic
Images cassées **uniquement sur Vercel** (local OK). Cause : optimiseur dimages Vercel (`/_next/image`) en échec — **quota Image Optimization (plan Hobby) épuisé** par les nombreuses previews. Le déploiement étant protégé par auth, confirmé par élimination (local 200 partout).

## Fix
- **`image-loader.ts`** : loader `next/image` custom → les images offi sont servies **directement par offi** à la bonne taille hébergée (**120/200/1000**, seules tailles réellement servies ; les autres redirigent vers une page derreur). Plus de transformation Vercel → **pas de quota, pas de point de panne**.
- `next.config` : `images.loader=custom` + `loaderFile`.
- **`WorkImage`** : composant partagé avec **repli `onError`** (placeholder au lieu de licône cassée), utilisé par CardWork / WorkSummaryCard / CompactLikeCard.

**Build prod OK**, loader unit-testé (5 tests), suite verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)