### PR TITLE
fix(ux mobile): onglets 2×2 propres + retrait Source orphelin

### DIFF
--- a/app/src/app/discover/page.tsx
+++ b/app/src/app/discover/page.tsx
@@ -38,6 +38,7 @@ export default async function DiscoverPage({ searchParams }: DiscoverPageProps =
       <SegmentedControl
         ariaLabel="Sections culturelles"
         value={section}
+        fullWidth
         items={[
           { label: 'Théâtre', value: 'theatre', href: '/discover?section=theatre' },
           { label: 'Cinéma', value: 'cinema', href: '/discover?section=cinema' },

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -356,7 +356,9 @@ a {
   gap: 0.375rem;
   padding: 0.375rem;
   border: 1px solid var(--color-border);
-  border-radius: 999px;
+  /* Rectangle arrondi (pas un stadium 999px) : reste propre quand les onglets
+     passent sur deux lignes en écran étroit (mobile). */
+  border-radius: var(--radius-lg);
   background: rgba(255, 255, 255, 0.72);
   box-shadow: var(--shadow-sm);
 }
@@ -390,7 +392,9 @@ a {
 }
 
 .segmented-control__item--full {
-  flex: 1 1 0;
+  /* base ~40% : 2 items tiennent sur une ligne (et grandissent à 50/50), 4 items
+     se rangent proprement en 2×2 au lieu de déborder sur écran étroit. */
+  flex: 1 1 40%;
 }
 
 .segmented-control__count {

--- a/app/src/features/auth/ui/NavBar.tsx
+++ b/app/src/features/auth/ui/NavBar.tsx
@@ -97,19 +97,6 @@ export default function NavBar() {
         </div>
       </div>
 
-      <div className="flex items-center justify-between gap-3 lg:hidden">
-        <a
-          className="text-xs font-medium text-[color:var(--color-text-muted)] transition hover:text-[color:var(--color-text)]"
-          href="https://www.offi.fr"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Source: offi.fr
-        </a>
-        {status === 'loading' ? (
-          <span className="text-xs text-[color:var(--color-text-muted)]">Chargement</span>
-        ) : null}
-      </div>
     </nav>
   )
 }

--- a/app/src/features/reactions/ui/LikesLibrary.tsx
+++ b/app/src/features/reactions/ui/LikesLibrary.tsx
@@ -201,6 +201,7 @@ export default function LikesLibrary({ current, archived, seen, friendsByWork, v
       <SegmentedControl
         ariaLabel="Filtrer les likes"
         value={view}
+        fullWidth
         items={[
           { label: 'Tous', value: 'all', href: '/likes', count: totalLikes },
           { label: 'À l’affiche', value: 'active', href: '/likes?view=active', count: active.length },


### PR DESCRIPTION
Bug daffichage iPhone (capture) : les onglets (4 items) débordaient/sétaient mal alignés et le « Source: offi.fr » flottait au-dessus du contenu.

- **Segmented control** : conteneur en **rectangle arrondi** (`--radius-lg`) au lieu du stadium 999px → propre quand ça passe sur 2 lignes. Items `--full` en `flex: 1 1 40%` → **2×2 net**.
- Onglets **Découverte & Likes** en `fullWidth`.
- **NavBar** : suppression de la ligne mobile « Source: offi.fr » orpheline (attribution conservée en desktop + lien « Voir sur Offi.fr » par carte).

lint/typecheck verts, 107 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)