### PR TITLE
fix(images): échec dimage non collant sur le deck (swipe)

### DIFF
--- a/app/src/features/works/ui/WorkImage.tsx
+++ b/app/src/features/works/ui/WorkImage.tsx
@@ -16,17 +16,21 @@ type WorkImageProps = {
 // Image d'œuvre avec repli gracieux : si la source est absente ou échoue à charger,
 // on rend le placeholder fourni plutôt que l'icône d'image cassée du navigateur.
 export default function WorkImage({ src, alt, sizes, className, priority, fallback }: WorkImageProps) {
-  const [failed, setFailed] = useState(false)
-  if (!src || failed) return <>{fallback}</>
+  // On mémorise l'URL qui a échoué (et non un booléen) : sinon, comme l'instance
+  // est réutilisée d'une carte à l'autre dans le deck, un seul échec masquerait
+  // toutes les images suivantes. Ici le repli ne s'applique qu'à l'URL fautive.
+  const [failedSrc, setFailedSrc] = useState<string | null>(null)
+  if (!src || failedSrc === src) return <>{fallback}</>
   return (
     <Image
+      key={src}
       src={src}
       alt={alt}
       fill
       sizes={sizes}
       className={className}
       priority={priority}
-      onError={() => setFailed(true)}
+      onError={() => setFailedSrc(src)}
     />
   )
 }

--- a/app/tests/work-image.test.tsx
+++ b/app/tests/work-image.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+// next/image → <img> simple qui transmet src/alt/onError.
+vi.mock('next/image', () => ({
+  default: ({ src, alt, onError }: { src: string; alt: string; onError?: () => void }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} onError={onError} />
+  ),
+}))
+
+import WorkImage from '@/features/works/ui/WorkImage'
+
+describe('WorkImage', () => {
+  it('affiche le fallback en l’absence de source', () => {
+    render(<WorkImage src={null} alt="x" sizes="80px" fallback={<span>NOIMG</span>} />)
+    expect(screen.getByText('NOIMG')).toBeInTheDocument()
+  })
+
+  it('un échec ne masque que l’URL fautive : changer de source ré-affiche l’image', () => {
+    const { rerender } = render(
+      <WorkImage src="https://files.offi.fr/a.jpg" alt="A" sizes="80px" fallback={<span>NOIMG</span>} />,
+    )
+    // erreur de chargement sur A → fallback
+    fireEvent.error(screen.getByAltText('A'))
+    expect(screen.getByText('NOIMG')).toBeInTheDocument()
+
+    // carte suivante (nouvelle URL) → l'image revient (l'échec n'est pas collant)
+    rerender(<WorkImage src="https://files.offi.fr/b.jpg" alt="B" sizes="80px" fallback={<span>NOIMG</span>} />)
+    expect(screen.getByAltText('B')).toBeInTheDocument()
+    expect(screen.queryByText('NOIMG')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
**Bug** : sur Découverte, après 2-3 swipes, plus dimages. `WorkImage` gardait un booléen `failed` qui ne se réinitialisait pas au changement de source — or linstance est réutilisée dune carte à lautre dans le deck, donc **un seul échec** (image manquante / blip réseau) masquait **toutes les cartes suivantes**.

**Fix** : on mémorise lURL fautive (`failedSrc`) au lieu dun booléen → le repli ne sapplique quà cette URL ; la carte suivante réaffiche son image. `key={src}` pour un remount propre. Test ajouté (échec sur A puis passage à B).

lint/typecheck verts, 109 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)