### PR TITLE
feat: expositions, concerts, visites & jeune public (6 sections)

### DIFF
--- a/app/src/app/discover/page.tsx
+++ b/app/src/app/discover/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next'
 import { requireSessionUserOrRedirect } from '@/features/auth/server/session'
-import { DEFAULT_WORK_SECTION, WORK_SECTION_VALUES, type WorkSection } from '@/features/works/section'
+import { DEFAULT_WORK_SECTION, WORK_SECTION_LABELS, WORK_SECTION_VALUES, type WorkSection } from '@/features/works/section'
 import { listDiscoverWorks } from '@/features/works/server/queries'
 import SwipeDeck from '@/features/works/ui/SwipeDeck'
 import SegmentedControl from '@/shared/ui/SegmentedControl'
@@ -39,10 +39,11 @@ export default async function DiscoverPage({ searchParams }: DiscoverPageProps =
         ariaLabel="Sections culturelles"
         value={section}
         fullWidth
-        items={[
-          { label: 'Théâtre', value: 'theatre', href: '/discover?section=theatre' },
-          { label: 'Cinéma', value: 'cinema', href: '/discover?section=cinema' },
-        ]}
+        items={WORK_SECTION_VALUES.map((s) => ({
+          label: WORK_SECTION_LABELS[s],
+          value: s,
+          href: `/discover?section=${s}`,
+        }))}
       />
 
       <SwipeDeck items={works.items} totalCount={works.total} />

--- a/app/src/features/reactions/ui/CompactLikeCard.tsx
+++ b/app/src/features/reactions/ui/CompactLikeCard.tsx
@@ -2,6 +2,7 @@
 
 import type { FriendSummaryDto } from '@/features/friendships/dto'
 import type { WorkCardDto } from '@/features/works/dto'
+import { workSectionLabel } from '@/features/works/section'
 import WorkImage from '@/features/works/ui/WorkImage'
 import { formatAvailability, formatEndsIn, formatPriceRange } from '@/features/works/ui/work-formatters'
 
@@ -20,7 +21,7 @@ type Props = {
 // gauche, titre + signaux d'action à droite (urgence, dispo, prix, amis).
 export default function CompactLikeCard({ work, fallbackTitle, friends, onOpen }: Props) {
   const title = work?.title ?? fallbackTitle
-  const sectionLabel = work?.section === 'cinema' ? 'Cinéma' : 'Théâtre'
+  const sectionLabel = workSectionLabel(work?.section)
   const ends = formatEndsIn(work?.endDate ?? null)
   const availability = formatAvailability(work?.availability ?? null)
   const priceLabel = formatPriceRange(work?.priceMin ?? null, work?.priceMax ?? null)

--- a/app/src/features/reactions/ui/LikesLibrary.tsx
+++ b/app/src/features/reactions/ui/LikesLibrary.tsx
@@ -5,6 +5,7 @@ import type { FriendSummaryDto } from '@/features/friendships/dto'
 import type { WorkCardDto } from '@/features/works/dto'
 import CompactLikeCard from '@/features/reactions/ui/CompactLikeCard'
 import LikeDetailModal, { type LikeBucket } from '@/features/reactions/ui/LikeDetailModal'
+import { WORK_SECTION_LABELS, WORK_SECTION_VALUES, type WorkSection } from '@/features/works/section'
 import { fetchJson } from '@/shared/lib/fetch-json'
 import SegmentedControl from '@/shared/ui/SegmentedControl'
 import SurfaceCard from '@/shared/ui/SurfaceCard'
@@ -61,7 +62,7 @@ export default function LikesLibrary({ current, archived, seen, friendsByWork, v
 
   // Filtres / tri (côté client).
   const [query, setQuery] = useState('')
-  const [section, setSection] = useState<'all' | 'theatre' | 'cinema'>('all')
+  const [section, setSection] = useState<'all' | WorkSection>('all')
   const [bookableOnly, setBookableOnly] = useState(false)
   const [sort, setSort] = useState<SortKey>('recent')
 
@@ -295,8 +296,8 @@ function Toolbar({
 }: {
   query: string
   onQuery: (v: string) => void
-  section: 'all' | 'theatre' | 'cinema'
-  onSection: (v: 'all' | 'theatre' | 'cinema') => void
+  section: 'all' | WorkSection
+  onSection: (v: 'all' | WorkSection) => void
   bookableOnly: boolean
   onBookable: (v: boolean) => void
   sort: SortKey
@@ -313,16 +314,19 @@ function Toolbar({
         aria-label="Rechercher dans mes likes"
       />
       <div className="flex flex-wrap items-center gap-2">
-        <SegmentedControl
-          ariaLabel="Filtrer par type"
+        <select
+          className="input w-auto py-1.5 text-sm"
           value={section}
-          onChange={(v) => onSection(v as 'all' | 'theatre' | 'cinema')}
-          items={[
-            { label: 'Tout', value: 'all' },
-            { label: 'Théâtre', value: 'theatre' },
-            { label: 'Cinéma', value: 'cinema' },
-          ]}
-        />
+          onChange={(e) => onSection(e.target.value as 'all' | WorkSection)}
+          aria-label="Filtrer par type"
+        >
+          <option value="all">Tout</option>
+          {WORK_SECTION_VALUES.map((s) => (
+            <option key={s} value={s}>
+              {WORK_SECTION_LABELS[s]}
+            </option>
+          ))}
+        </select>
         <label className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[color:var(--color-border)] bg-white/70 px-3 py-1.5 text-xs font-medium">
           <input type="checkbox" checked={bookableOnly} onChange={(e) => onBookable(e.target.checked)} />
           Réservable

--- a/app/src/features/works/section.ts
+++ b/app/src/features/works/section.ts
@@ -1,12 +1,52 @@
-export const WORK_SECTION_VALUES = ['theatre', 'cinema'] as const
+export const WORK_SECTION_VALUES = ['theatre', 'cinema', 'exposition', 'concert', 'visite', 'enfants'] as const
 
 export type WorkSection = (typeof WORK_SECTION_VALUES)[number]
 
 export const DEFAULT_WORK_SECTION: WorkSection = 'theatre'
 
+// Libellés FR affichés (badges, onglets, filtres).
+export const WORK_SECTION_LABELS: Record<WorkSection, string> = {
+  theatre: 'Théâtre',
+  cinema: 'Cinéma',
+  exposition: 'Exposition',
+  concert: 'Concert',
+  visite: 'Visite',
+  enfants: 'Jeune public',
+}
+
+export function workSectionLabel(section: string | null | undefined): string {
+  return (section && WORK_SECTION_LABELS[section as WorkSection]) || 'Sortie'
+}
+
+// Préfixe d'URL offi par section (pour l'inférence depuis une URL).
+const SECTION_URL_FRAGMENTS: Array<[WorkSection, string]> = [
+  ['cinema', '/cinema/'],
+  ['theatre', '/theatre/'],
+  ['exposition', '/expositions-musees/'],
+  ['concert', '/concerts/'],
+  ['visite', '/visites-conferences/'],
+  ['enfants', '/enfants/'],
+]
+
 export function inferWorkSectionFromUrl(url: string | null | undefined): WorkSection | null {
   if (!url) return null
-  if (url.includes('/cinema/')) return 'cinema'
-  if (url.includes('/theatre/')) return 'theatre'
+  for (const [section, fragment] of SECTION_URL_FRAGMENTS) {
+    if (url.includes(fragment)) return section
+  }
   return null
+}
+
+// Libellé du « crédit » principal selon la section (réalisateur / mise en scène /
+// artiste…). Utilisé pour préfixer Work.director à l'affichage.
+export function workDirectorLabel(section: string | null | undefined): string {
+  switch (section) {
+    case 'cinema':
+    case 'exposition':
+      return 'De'
+    case 'concert':
+    case 'visite':
+      return 'Avec'
+    default:
+      return 'Mise en scène' // theatre, enfants
+  }
 }

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -1,4 +1,5 @@
 import { splitGenres } from '@/features/works/category'
+import { workDirectorLabel, workSectionLabel } from '@/features/works/section'
 import WorkImage from '@/features/works/ui/WorkImage'
 import type { WorkCardDto } from '@/features/works/dto'
 import ExpandableDescription from '@/features/works/ui/ExpandableDescription'
@@ -16,12 +17,13 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
   const availability = formatAvailability(work.availability)
   const description = work.description?.trim()
   const genres = splitGenres(work.category).slice(0, 3)
-  const sectionLabel = work.section === 'cinema' ? 'Cinéma' : 'Théâtre'
-  const directorLabel = work.section === 'cinema' ? 'De' : 'Mise en scène'
+  const sectionLabel = workSectionLabel(work.section)
+  const directorLabel = workDirectorLabel(work.section)
   const hasFacts =
     genres.length > 0 || Boolean(durationLabel) || Boolean(priceLabel) || Boolean(availability)
-  // Ligne d'eyebrow : lieu (théâtre, avec arrondissement) ou nationalité·année (cinéma).
-  const venueLine = [work.venue, work.section === 'theatre' ? work.arrondissement : null]
+  // Ligne d'eyebrow : lieu + arrondissement (toutes sections « lieu » sauf le cinéma,
+  // qui affiche plutôt nationalité·année).
+  const venueLine = [work.venue, work.section !== 'cinema' ? work.arrondissement : null]
     .filter(Boolean)
     .join(' · ')
   const cinemaMeta = work.section === 'cinema' ? [work.country, work.year].filter(Boolean).join(' · ') : ''

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import type { WorkCardDto } from '@/features/works/dto'
+import { workDirectorLabel, workSectionLabel } from '@/features/works/section'
 import BadgeCategory from '@/features/works/ui/BadgeCategory'
 import WorkImage from '@/features/works/ui/WorkImage'
 import { formatDateRange, formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
@@ -21,9 +22,9 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
   const description = work?.description?.trim()
   const director = work?.director?.trim()
   const castNames = work?.cast?.slice(0, 5) ?? []
-  const directorLabel = work?.section === 'cinema' ? 'De' : 'Mise en scène'
+  const directorLabel = workDirectorLabel(work?.section)
   const venueLine = work
-    ? [work.venue, work.section === 'theatre' ? work.arrondissement : null].filter(Boolean).join(' · ')
+    ? [work.venue, work.section !== 'cinema' ? work.arrondissement : null].filter(Boolean).join(' · ')
     : ''
   const cinemaMeta = work?.section === 'cinema' ? [work.country, work.year].filter(Boolean).join(' · ') : ''
 
@@ -48,7 +49,7 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
 
         {work?.section ? (
           <span className="absolute bottom-4 right-4 rounded-full border border-white/35 bg-white/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-white backdrop-blur-sm">
-            {work.section === 'cinema' ? 'Cinéma' : 'Théâtre'}
+            {workSectionLabel(work.section)}
           </span>
         ) : null}
       </div>

--- a/app/tests/section.test.ts
+++ b/app/tests/section.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  WORK_SECTION_VALUES,
+  inferWorkSectionFromUrl,
+  workDirectorLabel,
+  workSectionLabel,
+} from '@/features/works/section'
+
+describe('sections', () => {
+  it('inclut les 6 sections', () => {
+    expect(WORK_SECTION_VALUES).toEqual(['theatre', 'cinema', 'exposition', 'concert', 'visite', 'enfants'])
+  })
+
+  it('infère la section depuis l’URL offi', () => {
+    expect(inferWorkSectionFromUrl('https://www.offi.fr/expositions-musees/grand-palais-5399/x-1.html')).toBe('exposition')
+    expect(inferWorkSectionFromUrl('https://www.offi.fr/concerts/cafe-1598/x-2.html')).toBe('concert')
+    expect(inferWorkSectionFromUrl('https://www.offi.fr/visites-conferences/g-1/x-3.html')).toBe('visite')
+    expect(inferWorkSectionFromUrl('https://www.offi.fr/enfants/t-1/x-4.html')).toBe('enfants')
+    expect(inferWorkSectionFromUrl('https://www.offi.fr/theatre/t-1/x-5.html')).toBe('theatre')
+    expect(inferWorkSectionFromUrl('https://www.offi.fr/cinema/evenement/x-6.html')).toBe('cinema')
+    expect(inferWorkSectionFromUrl('https://example.com/x')).toBeNull()
+  })
+
+  it('libellés et crédits par section', () => {
+    expect(workSectionLabel('exposition')).toBe('Exposition')
+    expect(workSectionLabel('enfants')).toBe('Jeune public')
+    expect(workSectionLabel('inconnu')).toBe('Sortie')
+    expect(workDirectorLabel('concert')).toBe('Avec')
+    expect(workDirectorLabel('cinema')).toBe('De')
+    expect(workDirectorLabel('theatre')).toBe('Mise en scène')
+  })
+})

--- a/scraper/Makefile
+++ b/scraper/Makefile
@@ -3,7 +3,7 @@
 PYTHON ?= ../.venv/bin/python
 OUT ?= ../data/offi.jsonl
 MAX_PAGES ?= 150
-SECTIONS ?= theatre,cinema
+SECTIONS ?= theatre,cinema,exposition,concert,visite,enfants
 REFRESH_AFTER_HOURS ?= 72
 CACHE ?= ../data/offi.jsonl
 

--- a/scraper/offi_scraper.py
+++ b/scraper/offi_scraper.py
@@ -40,6 +40,10 @@ CINEMA_PROGRAMME_URL = (
     f"{BASE_URL}/cinema/programme.html"
     "?rubrique=cinema&origine=homepage_rubrique&DateDebut=&DateFin=&NbDay=&arrondissment=&arrondissment=&GenreCinema="
 )
+EXPOSITION_PROGRAMME_URL = f"{BASE_URL}/expositions-musees/programme.html"
+CONCERT_PROGRAMME_URL = f"{BASE_URL}/concerts/programme.html"
+VISITE_PROGRAMME_URL = f"{BASE_URL}/visites-conferences/programme.html"
+ENFANTS_PROGRAMME_URL = f"{BASE_URL}/enfants/programme.html"
 USER_AGENTS = [
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
@@ -59,7 +63,7 @@ ADDRESS_RE = re.compile(
     r"\b\d{1,4}\s+(?:bis\s+|ter\s+)?[A-Za-zÀ-ÖØ-öø-ÿ'’\-. ]+?\b\d{5}\s+[A-Za-zÀ-ÖØ-öø-ÿ'’\-. ]+"
 )
 RUBRIC_RE = re.compile(r"rubrique\s+([^\.]+)\.", re.IGNORECASE)
-SECTION_VALUES = {"theatre", "cinema"}
+SECTION_VALUES = {"theatre", "cinema", "exposition", "concert", "visite", "enfants"}
 
 # Mois FR (longs + abréviations, avec ou sans point)
 MONTHS = {
@@ -150,6 +154,32 @@ SECTION_CONFIGS = {
         programme_url=CINEMA_PROGRAMME_URL,
         show_path_re=re.compile(r"^/cinema/evenement/[^/]+-\d+\.html$"),
         venue_path_re=None,
+        default_category=None,
+    ),
+    # Expositions, concerts, visites-conférences et jeune public : même structure
+    # d'URL que le théâtre (/<section>/<lieu>-<id>/<show>-<id>.html), listings statiques.
+    "exposition": SectionConfig(
+        programme_url=EXPOSITION_PROGRAMME_URL,
+        show_path_re=re.compile(r"^/expositions-musees/[^/]+-\d+/[^/]+-\d+\.html$"),
+        venue_path_re=re.compile(r"^/expositions-musees/[^/]+-\d+(?:\.html)?$"),
+        default_category=None,
+    ),
+    "concert": SectionConfig(
+        programme_url=CONCERT_PROGRAMME_URL,
+        show_path_re=re.compile(r"^/concerts/[^/]+-\d+/[^/]+-\d+\.html$"),
+        venue_path_re=re.compile(r"^/concerts/[^/]+-\d+(?:\.html)?$"),
+        default_category=None,
+    ),
+    "visite": SectionConfig(
+        programme_url=VISITE_PROGRAMME_URL,
+        show_path_re=re.compile(r"^/visites-conferences/[^/]+-\d+/[^/]+-\d+\.html$"),
+        venue_path_re=re.compile(r"^/visites-conferences/[^/]+-\d+(?:\.html)?$"),
+        default_category=None,
+    ),
+    "enfants": SectionConfig(
+        programme_url=ENFANTS_PROGRAMME_URL,
+        show_path_re=re.compile(r"^/enfants/[^/]+-\d+/[^/]+-\d+\.html$"),
+        venue_path_re=re.compile(r"^/enfants/[^/]+-\d+(?:\.html)?$"),
         default_category=None,
     ),
 }
@@ -402,6 +432,14 @@ class OffiScraper:
             return "theatre"
         if path.startswith("/cinema/"):
             return "cinema"
+        if path.startswith("/expositions-musees/"):
+            return "exposition"
+        if path.startswith("/concerts/"):
+            return "concert"
+        if path.startswith("/visites-conferences/"):
+            return "visite"
+        if path.startswith("/enfants/"):
+            return "enfants"
         return None
 
     def _get_section_config(self, section: Optional[str]) -> Optional[SectionConfig]:
@@ -413,7 +451,10 @@ class OffiScraper:
         section = show.section or self._infer_section_from_url(show.url)
         if section == "cinema":
             return bool(show.title and show.description)
-        return bool(show.title and show.category and show.venue and show.description)
+        if section == "theatre":
+            return bool(show.title and show.category and show.venue and show.description)
+        # expo/concert/visite/enfants : pas de catégorie fiable → titre + lieu + description.
+        return bool(show.title and show.venue and show.description)
 
     def _should_refresh_detail(self, cached_show: Optional[Show]) -> bool:
         if cached_show is None:
@@ -581,14 +622,17 @@ class OffiScraper:
         except Exception:
             return None
 
+    # Sections « lieu » dont l'URL est /<section>/<lieu>-<id>/<show>-<id>.html.
+    _VENUE_BASED_SECTIONS = {"theatre", "expositions-musees", "concerts", "visites-conferences", "enfants"}
+
     def _venue_from_show_url(self, show_url: str) -> Optional[str]:
-        """Extrait le théâtre depuis l’URL de la fiche (1er segment)."""
+        """Déduit le nom du lieu depuis l'URL de la fiche (2e segment), toutes
+        sections « lieu » confondues (théâtre, expo, concert, visite, enfants)."""
         try:
             path = urlparse(show_url).path
             parts = path.strip("/").split("/")
-            if len(parts) >= 2 and parts[0] == "theatre":
-                first = parts[1]  # ex: theatre-montparnasse-2825
-                base = re.sub(r"-\d+$", "", first)
+            if len(parts) >= 3 and parts[0] in self._VENUE_BASED_SECTIONS:
+                base = re.sub(r"-\d+$", "", parts[1])  # ex: cafe-de-la-danse-1598 → cafe-de-la-danse
                 if base:
                     name = base.replace("-", " ").strip()
                     return " ".join(w.capitalize() for w in name.split())
@@ -830,7 +874,9 @@ class OffiScraper:
             if venue:
                 show.venue = venue
 
-        config = self._get_section_config("theatre")
+        # Config de la section courante (et non "theatre" en dur) pour reconnaître le
+        # lien du lieu dans le fil d'ariane (/<section>/<lieu>-<id>...).
+        config = self._get_section_config(show.section) or self._get_section_config("theatre")
         breadcrumbs = soup.select("nav.breadcrumb a, .breadcrumb a, ol.breadcrumb a") or []
         for bc in reversed(breadcrumbs):
             href = bc.get("href", "")
@@ -1086,7 +1132,7 @@ def main():
     parser = argparse.ArgumentParser(description="Scraper Offi.fr - fiches 2 segments, venue fiable, dates robustes")
     parser.add_argument("--out", default="spectacles.jsonl", help="Fichier de sortie")
     parser.add_argument("--max-pages", type=int, default=150, help="Nombre max de pages de programme")
-    parser.add_argument("--sections", default="theatre,cinema", help="Sections à crawler (liste séparée par des virgules)")
+    parser.add_argument("--sections", default="theatre,cinema,exposition,concert,visite,enfants", help="Sections à crawler (liste séparée par des virgules)")
     parser.add_argument("--min-delay", type=float, default=0.7, help="Délai min entre requêtes")
     parser.add_argument("--max-delay", type=float, default=1.6, help="Délai max entre requêtes")
     parser.add_argument("--retries", type=int, default=4, help="Nombre de retries HTTP")

--- a/scraper/tests/test_sections.py
+++ b/scraper/tests/test_sections.py
@@ -1,0 +1,29 @@
+import unittest
+
+from scraper.offi_scraper import SECTION_CONFIGS, SECTION_VALUES, OffiScraper
+
+
+class SectionTests(unittest.TestCase):
+    def test_six_sections_configured(self):
+        expected = {"theatre", "cinema", "exposition", "concert", "visite", "enfants"}
+        self.assertEqual(set(SECTION_CONFIGS), expected)
+        self.assertEqual(SECTION_VALUES, expected)
+
+    def test_infer_section_from_url(self):
+        infer = OffiScraper._infer_section_from_url
+        self.assertEqual(infer("https://www.offi.fr/expositions-musees/grand-palais-5399/x-1.html"), "exposition")
+        self.assertEqual(infer("https://www.offi.fr/concerts/cafe-1598/x-2.html"), "concert")
+        self.assertEqual(infer("https://www.offi.fr/visites-conferences/g-1/x-3.html"), "visite")
+        self.assertEqual(infer("https://www.offi.fr/enfants/t-1/x-4.html"), "enfants")
+        self.assertEqual(infer("https://www.offi.fr/theatre/t-1/x-5.html"), "theatre")
+        self.assertEqual(infer("https://www.offi.fr/cinema/evenement/x-6.html"), "cinema")
+        self.assertIsNone(infer("https://example.com/x"))
+
+    def test_new_section_show_path_matches(self):
+        cfg = SECTION_CONFIGS["concert"]
+        self.assertTrue(cfg.show_path_re.match("/concerts/cafe-de-la-danse-1598/ondara-3239844.html"))
+        self.assertTrue(cfg.venue_path_re.match("/concerts/cafe-de-la-danse-1598.html"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/offi-pipeline.sh
+++ b/scripts/offi-pipeline.sh
@@ -61,7 +61,7 @@ SCRAPER_CMD=(
   "$ROOT_DIR/scraper/offi_scraper.py"
   --out "$TMP_FILE"
   --max-pages "${OFFI_MAX_PAGES:-150}"
-  --sections "${OFFI_SECTIONS:-theatre,cinema}"
+  --sections "${OFFI_SECTIONS:-theatre,cinema,exposition,concert,visite,enfants}"
   --min-delay "${OFFI_MIN_DELAY:-0.7}"
   --max-delay "${OFFI_MAX_DELAY:-1.6}"
   --retries "${OFFI_RETRIES:-4}"


### PR DESCRIPTION
Élargit le catalogue de **2 à 6 sections** (offi expose la même mécanique venue/show statique pour toutes : `/<section>/<lieu>-<id>/<show>-<id>.html`).

## Sections ajoutées
Exposition (`/expositions-musees`), Concert (`/concerts`), Visite-conférence (`/visites-conferences`), Jeune public (`/enfants`).

## Stack
- **`section.ts`** (source de vérité) : `WORK_SECTION_VALUES`, labels FR, inférence dURL, libellé de crédit par section → propagé à lingestion (`schemas`) et lAPI works.
- **Scraper** : `SECTION_CONFIGS` + URLs programme, inférence, complétude adaptée (titre+lieu+description) ; `_venue_from_show_url` + fil dariane **généralisés** à toutes les sections « lieu » (corrige `venue=null`).
- **UI** : labels via helpers, arrondissement pour toutes les sections lieu, **sélecteur Découverte 6 onglets (2×2)**, filtre /likes en `select`.
- pipeline/Makefile/CLI : 6 sections par défaut.
- **Tests** : section (app, 3) + sections (scraper, 3). **Mini-scrape concert validé en vrai** (lieu, dates, arrondissement, image OK).

Données peuplées juste après le merge (scrape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)