### PR TITLE
fix(ingest): upserts concurrents sans transaction (latence Neon)

### DIFF
--- a/app/src/features/offi-import/server/ingest.ts
+++ b/app/src/features/offi-import/server/ingest.ts
@@ -51,10 +51,13 @@ export async function readOffiFile(file: string) {
   return records
 }
 
-// Lots volontairement petits : une transaction trop grosse dépasse le timeout
-// Prisma (5 s) sur Neon distant (un lot de 500 prenait ~6 s → échec). ~50 upserts
-// par transaction (~0,6 s) garde une large marge, même en cas de latence.
-const INGEST_CHUNK_SIZE = 50
+// Concurrence par lot (PAS de transaction) : la forme batch de $transaction a un
+// timeout fixe de 5 s non configurable, qu'un lot dépasse dès que la latence Neon
+// est élevée (~125 ms/upsert observé → 50 upserts ≈ 6 s → échec). En lançant ~25
+// upserts en parallèle sans transaction, on garde la vitesse (concurrence) SANS
+// aucun cap de durée. Les upserts sont idempotents → la sémantique non-destructive
+// est préservée et une reprise éventuelle se réapplique sans dégât.
+const INGEST_CONCURRENCY = 25
 
 export async function ingestOffiFile(file: string) {
   if (!fs.existsSync(file)) {
@@ -64,13 +67,9 @@ export async function ingestOffiFile(file: string) {
   const records = await readOffiFile(file)
   let imported = 0
 
-  // Upsert par lots dans une transaction : 1 aller-retour réseau par lot au lieu
-  // d'un par enregistrement (mesuré jusqu'à ~200× plus rapide en base distante).
-  // La sémantique non-destructive est préservée : chaque upsert garde son `update`
-  // ciblé construit par buildWorkUpsert. Timeout relevé pour absorber la latence.
-  for (let i = 0; i < records.length; i += INGEST_CHUNK_SIZE) {
-    const chunk = records.slice(i, i + INGEST_CHUNK_SIZE)
-    await prisma.$transaction(
+  for (let i = 0; i < records.length; i += INGEST_CONCURRENCY) {
+    const chunk = records.slice(i, i + INGEST_CONCURRENCY)
+    await Promise.all(
       chunk.map((record) => {
         const { create, update } = buildWorkUpsert(record)
         return prisma.work.upsert({ where: { sourceUrl: record.url }, update, create })


### PR DESCRIPTION
Suite : même avec des lots de 50, la **forme batch de `$transaction` a un timeout fixe de 5 s non configurable**, dépassé dès que la latence Neon est élevée (~125 ms/upsert → 50 ≈ 6 s). 

On **supprime la transaction** : ~25 upserts **concurrents** (`Promise.all`) par lot → vitesse préservée, **aucun cap de durée**. Upserts idempotents → non-destructif intact.

**Validé en réel** : ingestion de 999 œuvres (expo/concert/visite/enfants) dans Neon, 0 erreur. Catalogue désormais : théâtre 1957, ciné 651, concert 375, expo 287, jeune public 191, visite 146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)