### PR TITLE
feat(ux): sélecteur de section Découverte en bande compacte défilable

### DIFF
--- a/app/src/app/discover/page.tsx
+++ b/app/src/app/discover/page.tsx
@@ -38,7 +38,7 @@ export default async function DiscoverPage({ searchParams }: DiscoverPageProps =
       <SegmentedControl
         ariaLabel="Sections culturelles"
         value={section}
-        fullWidth
+        scroll
         items={WORK_SECTION_VALUES.map((s) => ({
           label: WORK_SECTION_LABELS[s],
           value: s,

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -367,6 +367,36 @@ a {
   width: 100%;
 }
 
+/* Variante « bande défilable » : 1 rangée de pills, sans le panneau/track, scroll
+   horizontal discret. Compact pour beaucoup d'items (ex. les 6 sections). */
+.segmented-control--scroll {
+  display: flex;
+  flex-wrap: nowrap;
+  width: 100%;
+  overflow-x: auto;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.segmented-control--scroll::-webkit-scrollbar {
+  display: none;
+}
+.segmented-control--scroll .segmented-control__item {
+  flex: 0 0 auto;
+  min-height: 2.4rem;
+  white-space: nowrap;
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.72);
+}
+.segmented-control--scroll .segmented-control__item--active {
+  border-color: var(--color-accent);
+  background: var(--color-surface-strong);
+  color: var(--color-text);
+}
+
 .segmented-control__item {
   display: inline-flex;
   align-items: center;

--- a/app/src/shared/ui/SegmentedControl.tsx
+++ b/app/src/shared/ui/SegmentedControl.tsx
@@ -17,6 +17,9 @@ type SegmentedControlProps = {
   ariaLabel: string
   onChange?: (value: string) => void
   fullWidth?: boolean
+  // Bande horizontale défilable (pills) au lieu du panneau qui passe à la ligne :
+  // compact (1 rangée), idéal quand il y a beaucoup d'items (ex. 6 sections).
+  scroll?: boolean
 }
 
 export default function SegmentedControl({
@@ -25,10 +28,15 @@ export default function SegmentedControl({
   ariaLabel,
   onChange,
   fullWidth = false,
+  scroll = false,
 }: SegmentedControlProps) {
   return (
     <div
-      className={cn('segmented-control', fullWidth && 'segmented-control--full')}
+      className={cn(
+        'segmented-control',
+        fullWidth && 'segmented-control--full',
+        scroll && 'segmented-control--scroll',
+      )}
       role="tablist"
       aria-label={ariaLabel}
     >


### PR DESCRIPTION
Le sélecteur 6 sections en grille 2×3 (gros panneau) prenait trop de hauteur sur mobile et repoussait la carte. Nouvelle variante **`scroll`** du `SegmentedControl` : **une seule rangée de pills défilable** horizontalement, sans le panneau/track → bien plus compact. Les onglets /likes gardent leur 2×2.

lint/typecheck verts, 112 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)