### PR TITLE
fix(mobile): swipe fiable + boutons réactifs + anti retour/scroll

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -44,6 +44,25 @@ body {
   font-family: var(--font-manrope);
   color: var(--color-text);
   background: linear-gradient(180deg, var(--color-page-top) 0%, var(--color-page) 100%);
+  /* Limite le rebond/pull-to-refresh et le retour-arrière par swipe horizontal. */
+  overscroll-behavior-y: contain;
+  overscroll-behavior-x: none;
+}
+
+/* Réactivité tactile : supprime le délai de 300 ms (double-tap zoom) et le flash
+   gris au tap ; un retour :active explicite donne un feedback immédiat. */
+button,
+a,
+select,
+[role='button'],
+[role='tab'] {
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.btn:active:not(:disabled),
+.segmented-control__item:active {
+  transform: scale(0.97);
 }
 
 a {

--- a/app/src/features/works/ui/SwipeDeck.tsx
+++ b/app/src/features/works/ui/SwipeDeck.tsx
@@ -71,6 +71,7 @@ export default function SwipeDeck({ items, totalCount }: Props) {
   const [history, setHistory] = useState<{ workId: string; status: 'LIKE' | 'DISLIKE' }[]>([])
 
   const dragging = useRef(false)
+  const startX = useRef(0)
   const cardRef = useRef<HTMLDivElement>(null)
   const current = items[index]
   const hasMore = index < items.length
@@ -233,8 +234,11 @@ export default function SwipeDeck({ items, totalCount }: Props) {
     (event: React.PointerEvent) => {
       if (pending) return
       dragging.current = true
+      startX.current = event.clientX
       setDragStartTs(performance.now())
-      ;(event.target as Element).setPointerCapture?.(event.pointerId)
+      // Capture sur la carte (et non l'enfant touché) → tous les déplacements lui
+      // sont routés, le geste ne « fuit » pas vers le scroll/retour navigateur.
+      cardRef.current?.setPointerCapture?.(event.pointerId)
     },
     [pending],
   )
@@ -242,7 +246,9 @@ export default function SwipeDeck({ items, totalCount }: Props) {
   const onPointerMove = useCallback(
     (event: React.PointerEvent) => {
       if (!dragging.current || pending) return
-      setDragX((value) => value + event.movementX)
+      // Delta absolu depuis le point de départ : `movementX` est peu fiable
+      // (souvent 0) sur tactile mobile → le drag ne suivait pas le doigt.
+      setDragX(event.clientX - startX.current)
     },
     [pending],
   )


### PR DESCRIPTION
Deux soucis mobiles signalés.

**Swipe qui se confond avec scroll/retour** : `onPointerMove` utilisait `event.movementX`, **peu fiable (souvent 0) sur tactile** → le drag ne suivait pas le doigt et le geste « fuyait » vers le scroll ou le retour navigateur. Fix : delta **absolu** (`clientX - startX`) + capture du pointeur **sur la carte**.

**Boutons peu réactifs** : `touch-action: manipulation` (supprime le délai 300 ms du double-tap-zoom), `-webkit-tap-highlight-color: transparent` + retour **`:active`** (léger scale) → feedback immédiat. `overscroll-behavior` y:contain / x:none limite le pull-to-refresh et le retour-arrière par swipe horizontal.

lint/typecheck verts, test swipe vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)