### PR TITLE
feat(cinema): salles où le film est programmé (N salles + échantillon)

### DIFF
--- a/app/prisma/migrations/20260609160000_add_cinema_venues/migration.sql
+++ b/app/prisma/migrations/20260609160000_add_cinema_venues/migration.sql
@@ -1,0 +1,5 @@
+-- Salles de cinéma où un film est programmé (additif, non destructif) :
+--  - cinemaVenueCount : nombre de salles uniques
+--  - cinemaVenues     : échantillon de noms de salles
+ALTER TABLE "Work" ADD COLUMN "cinemaVenueCount" INTEGER;
+ALTER TABLE "Work" ADD COLUMN "cinemaVenues" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -90,6 +90,8 @@ model Work {
   year      Int?           // année de production (cinéma)
   availability String?     // dispo billetterie (schema.org) : "InStock", "SoldOut"…
   currency  String?        // devise du prix : "EUR"
+  cinemaVenueCount Int?    // nb de salles où le film est programmé (cinéma)
+  cinemaVenues String[]    // échantillon de noms de salles (cinéma)
   sourceUrl String    @unique
 
   // Lien vers le lieu (pertinent surtout pour le théâtre : un spectacle = un lieu ;

--- a/app/src/features/offi-import/mappers.ts
+++ b/app/src/features/offi-import/mappers.ts
@@ -30,6 +30,8 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
     year: record.year ?? null,
     availability: record.availability ?? null,
     currency: record.currency ?? null,
+    cinemaVenueCount: record.cinema_venue_count ?? null,
+    cinemaVenues: record.cinema_venues ?? [],
     sourceUrl: record.url,
   }
 
@@ -55,6 +57,8 @@ export function buildWorkUpsert(record: OffiWorkRecord): {
   if (record.year != null) update.year = record.year
   if (record.availability != null) update.availability = record.availability
   if (record.currency != null) update.currency = record.currency
+  if (record.cinema_venue_count != null) update.cinemaVenueCount = record.cinema_venue_count
+  if (record.cinema_venues.length > 0) update.cinemaVenues = record.cinema_venues
 
   return { create, update }
 }

--- a/app/src/features/offi-import/schemas.ts
+++ b/app/src/features/offi-import/schemas.ts
@@ -77,6 +77,14 @@ export const offiWorkSchema = z
     year: nullableYear,
     availability: nullableString(40),
     currency: nullableString(8),
+    cinema_venue_count: z.preprocess(
+      (value) => (value === undefined || value === null || value === '' ? null : value),
+      z.number().int().min(0).max(5000).nullable(),
+    ),
+    cinema_venues: z.preprocess(
+      (value) => (Array.isArray(value) ? value : []),
+      z.array(z.string().trim().min(1).max(160)).max(20),
+    ),
     date_start: nullableIsoDate,
     date_end: nullableIsoDate,
     duration_min: nullableInt,

--- a/app/src/features/works/dto.ts
+++ b/app/src/features/works/dto.ts
@@ -22,6 +22,8 @@ export const workCardSelect = {
   year: true,
   availability: true,
   currency: true,
+  cinemaVenueCount: true,
+  cinemaVenues: true,
   sourceUrl: true,
   venue_ref: {
     select: { name: true, metro: true, access: true, phone: true, city: true },
@@ -51,6 +53,8 @@ export type WorkCardDto = {
   year: number | null
   availability: string | null
   currency: string | null
+  cinemaVenueCount: number | null
+  cinemaVenues: string[]
   sourceUrl: string | null
   venueInfo: {
     name: string
@@ -83,6 +87,8 @@ export function mapWorkToCardDto(work: WorkCardRecord): WorkCardDto {
     year: work.year,
     availability: work.availability,
     currency: work.currency,
+    cinemaVenueCount: work.cinemaVenueCount,
+    cinemaVenues: work.cinemaVenues,
     sourceUrl: work.sourceUrl,
     venueInfo: work.venue_ref
       ? {

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -27,6 +27,13 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
     .filter(Boolean)
     .join(' · ')
   const cinemaMeta = work.section === 'cinema' ? [work.country, work.year].filter(Boolean).join(' · ') : ''
+  // Cinéma : « N salles — quelques noms » (un film passe dans plusieurs cinémas).
+  const cinemaVenuesLine =
+    work.section === 'cinema' && work.cinemaVenueCount
+      ? `${work.cinemaVenueCount} salle${work.cinemaVenueCount > 1 ? 's' : ''}${
+          work.cinemaVenues.length ? ' · ' + work.cinemaVenues.slice(0, 2).join(', ') : ''
+        }`
+      : ''
   // Infos pratiques du lieu (théâtre relié) : métro + accès.
   const venueMetro = work.venueInfo?.metro?.trim()
   const venueAccess = work.venueInfo?.access?.trim()
@@ -98,6 +105,10 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
             {venueMetro ? <span>🚇 {venueMetro}</span> : null}
             {venueAccess ? <span>♿ {venueAccess}</span> : null}
           </p>
+        ) : null}
+
+        {cinemaVenuesLine ? (
+          <p className="text-xs text-[color:var(--color-text-muted)]">🎬 {cinemaVenuesLine}</p>
         ) : null}
 
         {hasFacts ? (

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -27,6 +27,12 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
     ? [work.venue, work.section !== 'cinema' ? work.arrondissement : null].filter(Boolean).join(' · ')
     : ''
   const cinemaMeta = work?.section === 'cinema' ? [work.country, work.year].filter(Boolean).join(' · ') : ''
+  const cinemaVenuesLine =
+    work?.section === 'cinema' && work.cinemaVenueCount
+      ? `🎬 ${work.cinemaVenueCount} salle${work.cinemaVenueCount > 1 ? 's' : ''}${
+          work.cinemaVenues.length ? ' · ' + work.cinemaVenues.slice(0, 3).join(', ') : ''
+        }`
+      : ''
 
   return (
     <SurfaceCard className={cn('flex h-full flex-col overflow-hidden p-0', className)} tone="muted">
@@ -59,6 +65,7 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
           <h3 className="line-clamp-2 text-lg font-semibold tracking-[-0.03em] text-[color:var(--color-text)]">{title}</h3>
           {venueLine ? <p className="text-sm font-medium text-muted-foreground">{venueLine}</p> : null}
           {cinemaMeta ? <p className="text-sm font-medium text-muted-foreground">{cinemaMeta}</p> : null}
+          {cinemaVenuesLine ? <p className="text-sm text-muted-foreground">{cinemaVenuesLine}</p> : null}
           {director || castNames.length > 0 ? (
             <div className="space-y-0.5 text-sm leading-6">
               {director ? (

--- a/scraper/extract_credits_cli.py
+++ b/scraper/extract_credits_cli.py
@@ -20,6 +20,7 @@ def main() -> None:
     arrondissement = parsers.extract_arrondissement(soup)
     offers = parsers.extract_offers(soup)
     description = parsers.extract_description(soup)
+    cinema_venue_count, cinema_venues = parsers.extract_cinema_venues(soup)
     print(
         json.dumps(
             {
@@ -33,6 +34,8 @@ def main() -> None:
                 "price_min": offers["price_min"],
                 "price_max": offers["price_max"],
                 "description": description,
+                "cinema_venue_count": cinema_venue_count,
+                "cinema_venues": cinema_venues,
             },
             ensure_ascii=False,
         )

--- a/scraper/offi_scraper.py
+++ b/scraper/offi_scraper.py
@@ -207,6 +207,8 @@ class Show:
     year: Optional[int] = None             # année de production (cinéma)
     availability: Optional[str] = None     # dispo billetterie : "InStock", "SoldOut"…
     currency: Optional[str] = None         # devise du prix : "EUR"
+    cinema_venue_count: Optional[int] = None  # nb de salles où le film passe (cinéma)
+    cinema_venues: list[str] = field(default_factory=list)  # échantillon de noms de salles
     crawled_at: Optional[str] = None
 
     def is_empty(self) -> bool:
@@ -413,6 +415,8 @@ class OffiScraper:
             year=payload.get("year"),
             availability=payload.get("availability"),
             currency=payload.get("currency"),
+            cinema_venue_count=payload.get("cinema_venue_count"),
+            cinema_venues=payload.get("cinema_venues") or [],
             crawled_at=payload.get("crawled_at"),
         )
 
@@ -964,6 +968,11 @@ class OffiScraper:
                 show.country = country
             if not show.year and year:
                 show.year = year
+
+        count, venues = parsers.extract_cinema_venues(soup)
+        if count:
+            show.cinema_venue_count = count
+            show.cinema_venues = venues
 
         return show
 

--- a/scraper/parsers.py
+++ b/scraper/parsers.py
@@ -431,3 +431,17 @@ def extract_description(soup) -> Optional[str]:
         return _clean_text(meta_desc["content"])
 
     return None
+
+
+# --- Cinéma : salles où le film est programmé -----------------------------------
+# Un film passe dans de nombreuses salles (.nomSalle, répétées par horaire). On
+# dédoublonne et on renvoie (nombre de salles uniques, échantillon de noms).
+def extract_cinema_venues(soup, sample_size: int = 8) -> tuple[int, list[str]]:
+    seen: list[str] = []
+    keys: set[str] = set()
+    for el in soup.select(".nomSalle"):
+        name = _clean_text(el.get_text(" ", strip=True))
+        if name and name.lower() not in keys:
+            keys.add(name.lower())
+            seen.append(name)
+    return len(seen), seen[:sample_size]

--- a/scraper/tests/test_parsers.py
+++ b/scraper/tests/test_parsers.py
@@ -253,5 +253,21 @@ class ExtractDescriptionTests(unittest.TestCase):
         self.assertIsNone(parsers.extract_description(_soup('<div>rien</div>')))
 
 
+class ExtractCinemaVenuesTests(unittest.TestCase):
+    def test_dedup_and_count(self):
+        html = (
+            '<span class="nomSalle">Le Chaplin</span>'
+            '<span class="nomSalle">UGC Les Halles</span>'
+            '<span class="nomSalle">Le Chaplin</span>'  # doublon (autre horaire)
+            '<span class="nomSalle">Le Balzac</span>'
+        )
+        count, sample = parsers.extract_cinema_venues(_soup(html))
+        self.assertEqual(count, 3)
+        self.assertEqual(sample, ['Le Chaplin', 'UGC Les Halles', 'Le Balzac'])
+
+    def test_empty(self):
+        self.assertEqual(parsers.extract_cinema_venues(_soup('<div>rien</div>')), (0, []))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Un film ne joue pas dans **un** lieu mais dans de nombreuses salles. On extrait de la fiche film le **nombre de salles uniques** (`.nomSalle` dédoublonné) + un **échantillon de noms** → affiché « 🎬 N salles · Pathé Les Halles, UGC… » sur la carte Découverte et la modale /likes. Les **horaires** (volatils) ne sont pas stockés → le lien « Voir sur Offi.fr » mène au détail.

- `parsers.extract_cinema_venues` (pure, +2 tests). `Show` + complétion ciné + CLI de backfill.
- Prisma `cinemaVenueCount`/`cinemaVenues` + migration (appliquée sur Neon) ; schemas/mappers ; DTO ; affichage. **112 tests** verts. Test live : 129 salles sur un film.

Données peuplées après merge (backfill ciné).

🤖 Generated with [Claude Code](https://claude.com/claude-code)