### PR TITLE
feat(ux): compteur de carte en surimpression sur limage

### DIFF
--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -10,7 +10,7 @@ const AVAILABILITY_CHIP_CLASS: Record<'success' | 'danger' | 'warning', string> 
   danger: 'bg-[color:var(--color-danger-soft)] text-[color:var(--color-danger)]',
 }
 
-export default function CardWork({ work }: { work: WorkCardDto }) {
+export default function CardWork({ work, counter }: { work: WorkCardDto; counter?: string }) {
   const durationLabel = formatDuration(work.durationMin)
   const priceLabel = formatPriceRange(work.priceMin, work.priceMax)
   const availability = formatAvailability(work.availability)
@@ -58,6 +58,11 @@ export default function CardWork({ work }: { work: WorkCardDto }) {
         <span className="absolute right-3 top-3 rounded-full border border-white/35 bg-black/35 px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-white backdrop-blur-sm">
           {sectionLabel}
         </span>
+        {counter ? (
+          <span className="absolute left-3 top-3 rounded-full border border-white/35 bg-black/35 px-3 py-1 text-xs font-medium tabular-nums text-white backdrop-blur-sm">
+            {counter}
+          </span>
+        ) : null}
       </div>
 
       <div className="flex flex-col gap-2 p-4">

--- a/app/src/features/works/ui/SwipeDeck.tsx
+++ b/app/src/features/works/ui/SwipeDeck.tsx
@@ -303,10 +303,6 @@ export default function SwipeDeck({ items, totalCount }: Props) {
       aria-label="Sélection de découvertes à balayer"
       className="mx-auto flex w-full max-w-5xl flex-col gap-3 select-none"
     >
-      <div className="page-meta">
-        <span className="chip">Carte {Math.min(index + 1, visibleTotal)} / {visibleTotal}</span>
-      </div>
-
       <div className="relative flex min-h-[30rem] items-center justify-center pb-2">
         {nextItems.map((item, previewIndex) => (
           <div
@@ -333,7 +329,7 @@ export default function SwipeDeck({ items, totalCount }: Props) {
           style={{ transform, pointerEvents: pending ? 'none' : 'auto' }}
           className="relative z-10 h-full w-full max-w-xl cursor-grab touch-none rounded-[var(--radius-2xl)] border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-2 shadow-[var(--shadow-lg)] will-change-transform"
         >
-          <CardWork work={current} />
+          <CardWork work={current} counter={`${Math.min(index + 1, visibleTotal)} / ${visibleTotal}`} />
           <div className="pointer-events-none absolute inset-x-6 top-6 flex items-start justify-between">
             <span
               aria-hidden


### PR DESCRIPTION
« Carte X/Y » prenait une ligne dédiée au-dessus du deck. Déplacé **en surimpression en haut à gauche de limage** (symétrique au badge de section) ; ligne supprimée → la carte remonte encore.

lint/typecheck verts, tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)