### PR TITLE
feat: lien vers la source (site officiel du lieu) + bouton copier

### DIFF
--- a/app/prisma/migrations/20260609170000_add_venue_website/migration.sql
+++ b/app/prisma/migrations/20260609170000_add_venue_website/migration.sql
@@ -1,0 +1,2 @@
+-- Site officiel du lieu (lien rel="external" récupéré sur la page lieu offi).
+ALTER TABLE "Venue" ADD COLUMN "website" TEXT;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -129,6 +129,7 @@ model Venue {
   access String?                  // "Accès PMR, Espace climatisé"
 
   imageUrl  String?
+  website   String?                  // site officiel du lieu (rel="external" sur offi)
   sourceUrl String @unique
 
   works Work[]

--- a/app/scripts/backfill-venue-websites.ts
+++ b/app/scripts/backfill-venue-websites.ts
@@ -1,0 +1,78 @@
+// Remplit Venue.website (site officiel) sur les lieux déjà en base qui ne l'ont pas
+// encore. Re-scrape léger de la page lieu offi → lien rel="external" (parsers.extract_venue).
+// Re-runnable : ne traite que les lieux où website est null.
+//
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/backfill-venue-websites.ts [limit]
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { prisma } from '@/server/db'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const scraperDir = path.resolve(here, '../../scraper')
+const PY = path.join(scraperDir, '.venv/bin/python')
+const CLI = path.join(scraperDir, 'extract_venue_cli.py')
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+
+const limit = Number(process.argv[2] ?? 1000)
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function fetchHtml(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(15_000) })
+    return res.ok ? await res.text() : null
+  } catch {
+    return null
+  }
+}
+
+function extractWebsite(html: string, url: string, kind: string): string | null {
+  const res = spawnSync(PY, [CLI, url, kind], {
+    input: html,
+    encoding: 'utf-8',
+    cwd: scraperDir,
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 10_000,
+    killSignal: 'SIGKILL',
+  })
+  if (res.status !== 0 || !res.stdout) return null
+  try {
+    const parsed = JSON.parse(res.stdout)
+    return parsed?.website ?? null
+  } catch {
+    return null
+  }
+}
+
+async function main() {
+  const venues = await prisma.venue.findMany({
+    where: { website: null },
+    select: { id: true, kind: true, sourceUrl: true },
+    take: limit,
+  })
+  let updated = 0
+  let missing = 0
+  for (const v of venues) {
+    const html = await fetchHtml(v.sourceUrl)
+    if (!html) {
+      missing += 1
+      continue
+    }
+    const website = extractWebsite(html, v.sourceUrl, v.kind)
+    if (website) {
+      await prisma.venue.update({ where: { id: v.id }, data: { website } })
+      updated += 1
+    } else {
+      missing += 1
+    }
+    await sleep(300)
+  }
+  console.log(JSON.stringify({ scanned: venues.length, updated, missing }))
+}
+
+main()
+  .catch((error) => {
+    console.error('[backfill-venue-websites]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/app/scripts/backfill-venues.ts
+++ b/app/scripts/backfill-venues.ts
@@ -1,12 +1,15 @@
-// Backfill / ingestion des lieux (Venue) depuis offi, + lien Work.venueId (théâtre).
+// Backfill / ingestion des lieux (Venue) depuis offi, + lien Work.venueId.
 //
-// - Théâtre : l'URL de la page lieu se déduit de l'URL du spectacle
-//   (/theatre/<venue>-<id>/<show>.html → /theatre/<venue>-<id>.html). On upsert le
-//   lieu et on relie tous les spectacles de ce lieu (venueId).
+// - Sections « lieu » (théâtre, expo, concert, visite, enfants) : un spectacle = un
+//   lieu, l'URL de la page lieu se déduit de l'URL du spectacle
+//   (/<seg>/<lieu>-<id>/<show>.html → /<seg>/<lieu>-<id>.html). On upsert le lieu
+//   (avec son site officiel) et on relie tous les spectacles de ce lieu (venueId).
 // - Cinéma : un film joue dans plusieurs salles → pas de lien 1:1. On récolte les
 //   salles listées sur les fiches films (catalogue uniquement).
 //
-// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/backfill-venues.ts [theatre|cinema|all] [limit]
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/backfill-venues.ts \
+//   [theatre|exposition|concert|visite|enfants|cinema|venues|all] [limit]
+//   venues = toutes les sections « lieu » ; all = venues + cinema.
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
@@ -18,8 +21,17 @@ const PY = path.join(scraperDir, '.venv/bin/python')
 const CLI = path.join(scraperDir, 'extract_venue_cli.py')
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
 
-const mode = (process.argv[2] ?? 'all') as 'theatre' | 'cinema' | 'all'
+const mode = process.argv[2] ?? 'all'
 const limit = Number(process.argv[3] ?? 1000)
+
+// Sections « lieu » → segment d'URL offi correspondant.
+const VENUE_SECTIONS: Record<string, string> = {
+  theatre: 'theatre',
+  exposition: 'expositions-musees',
+  concert: 'concerts',
+  visite: 'visites-conferences',
+  enfants: 'enfants',
+}
 
 type VenueData = {
   offi_id: number
@@ -35,11 +47,12 @@ type VenueData = {
   metro: string | null
   access: string | null
   image: string | null
+  website: string | null
   source_url: string
 }
 
-function theatreVenueUrlFromShow(url: string): string | null {
-  const m = url.match(/^(https?:\/\/[^/]+\/theatre\/[^/]+-\d+)\/[^/]+-\d+(?:\.html)?$/)
+function venueUrlFromShow(url: string, seg: string): string | null {
+  const m = url.match(new RegExp(`^(https?://[^/]+/${seg}/[^/]+-\\d+)/[^/]+-\\d+(?:\\.html)?$`))
   return m ? `${m[1]}.html` : null
 }
 
@@ -98,6 +111,7 @@ async function upsertVenue(v: VenueData): Promise<string> {
     metro: v.metro,
     access: v.access,
     imageUrl: v.image,
+    website: v.website,
     sourceUrl: v.source_url,
   }
   const venue = await prisma.venue.upsert({ where: { offiId: v.offi_id }, create: data, update: data })
@@ -106,15 +120,16 @@ async function upsertVenue(v: VenueData): Promise<string> {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
-async function backfillTheatre() {
+async function backfillVenueSection(section: string) {
+  const seg = VENUE_SECTIONS[section]
   const works = await prisma.work.findMany({
-    where: { section: 'theatre' },
+    where: { section },
     select: { id: true, sourceUrl: true },
   })
   // Regroupe les spectacles par URL de lieu déduite.
   const byVenueUrl = new Map<string, string[]>()
   for (const w of works) {
-    const venueUrl = theatreVenueUrlFromShow(w.sourceUrl)
+    const venueUrl = venueUrlFromShow(w.sourceUrl, seg)
     if (!venueUrl) continue
     const list = byVenueUrl.get(venueUrl) ?? []
     list.push(w.id)
@@ -122,7 +137,7 @@ async function backfillTheatre() {
   }
 
   // Ne (re)traite que les lieux pas encore en base, dans la limite demandée.
-  const existing = new Set((await prisma.venue.findMany({ where: { kind: 'theatre' }, select: { sourceUrl: true } })).map((v) => v.sourceUrl))
+  const existing = new Set((await prisma.venue.findMany({ where: { kind: section }, select: { sourceUrl: true } })).map((v) => v.sourceUrl))
   const urls = [...byVenueUrl.keys()].filter((u) => !existing.has(u)).slice(0, limit)
 
   let venues = 0
@@ -130,7 +145,7 @@ async function backfillTheatre() {
   for (const url of urls) {
     const html = await fetchHtml(url)
     if (!html) continue
-    const v = extractVenue(html, url, 'theatre')
+    const v = extractVenue(html, url, section)
     if (!v) continue
     const venueId = await upsertVenue(v)
     venues += 1
@@ -142,15 +157,15 @@ async function backfillTheatre() {
 
   // Relink (sans fetch) : spectacles encore non liés dont le lieu est déjà en base.
   // Couvre les nouveaux spectacles ajoutés dans un lieu déjà connu.
-  const knownVenues = await prisma.venue.findMany({ where: { kind: 'theatre' }, select: { id: true, offiId: true } })
+  const knownVenues = await prisma.venue.findMany({ where: { kind: section }, select: { id: true, offiId: true } })
   const venueIdByOffiId = new Map(knownVenues.map((v) => [v.offiId, v.id]))
   const unlinked = await prisma.work.findMany({
-    where: { section: 'theatre', venueId: null },
+    where: { section, venueId: null },
     select: { id: true, sourceUrl: true },
   })
   const relinkGroups = new Map<string, string[]>()
   for (const w of unlinked) {
-    const offiId = offiIdFromUrl(theatreVenueUrlFromShow(w.sourceUrl))
+    const offiId = offiIdFromUrl(venueUrlFromShow(w.sourceUrl, seg))
     const vid = offiId != null ? venueIdByOffiId.get(offiId) : undefined
     if (!vid) continue
     const list = relinkGroups.get(vid) ?? []
@@ -163,7 +178,7 @@ async function backfillTheatre() {
     relinked += res.count
   }
 
-  console.log(JSON.stringify({ segment: 'theatre', venues, linkedWorks: linked, relinked, candidates: urls.length }))
+  console.log(JSON.stringify({ segment: section, venues, linkedWorks: linked, relinked, candidates: urls.length }))
 }
 
 async function backfillCinema() {
@@ -199,7 +214,12 @@ async function backfillCinema() {
 }
 
 async function main() {
-  if (mode === 'theatre' || mode === 'all') await backfillTheatre()
+  const venueSections = Object.keys(VENUE_SECTIONS)
+  if (mode === 'all' || mode === 'venues') {
+    for (const section of venueSections) await backfillVenueSection(section)
+  } else if (venueSections.includes(mode)) {
+    await backfillVenueSection(mode)
+  }
   if (mode === 'cinema' || mode === 'all') await backfillCinema()
 }
 

--- a/app/src/features/works/dto.ts
+++ b/app/src/features/works/dto.ts
@@ -26,7 +26,7 @@ export const workCardSelect = {
   cinemaVenues: true,
   sourceUrl: true,
   venue_ref: {
-    select: { name: true, metro: true, access: true, phone: true, city: true },
+    select: { name: true, metro: true, access: true, phone: true, city: true, website: true },
   },
 } satisfies Prisma.WorkSelect
 
@@ -62,6 +62,7 @@ export type WorkCardDto = {
     access: string | null
     phone: string | null
     city: string | null
+    website: string | null
   } | null
 }
 
@@ -97,6 +98,7 @@ export function mapWorkToCardDto(work: WorkCardRecord): WorkCardDto {
           access: work.venue_ref.access,
           phone: work.venue_ref.phone,
           city: work.venue_ref.city,
+          website: work.venue_ref.website,
         }
       : null,
   }

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -1,5 +1,6 @@
 import { workDirectorLabel, workSectionLabel } from '@/features/works/section'
 import WorkImage from '@/features/works/ui/WorkImage'
+import VenueSource from '@/features/works/ui/VenueSource'
 import type { WorkCardDto } from '@/features/works/dto'
 import ExpandableDescription from '@/features/works/ui/ExpandableDescription'
 import { formatAvailability, formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
@@ -68,9 +69,11 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
       <div className="flex flex-col gap-2 p-4">
         <div className="space-y-1">
           {venueLine ? (
-            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
-              📍 {venueLine}
-            </p>
+            <VenueSource
+              label={`📍 ${venueLine}`}
+              website={work.venueInfo?.website ?? null}
+              textClassName="text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]"
+            />
           ) : null}
           {cinemaMeta ? (
             <p className="text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
@@ -135,7 +138,9 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
 
         {description ? <ExpandableDescription text={description} /> : null}
 
-        {work.sourceUrl ? (
+        {/* Fallback Offi : seulement quand le lieu n'a pas de site officiel (ex. cinéma,
+            ou lieu non encore relié). Sinon, la source est portée par le nom du lieu. */}
+        {work.sourceUrl && !work.venueInfo?.website ? (
           <a
             href={work.sourceUrl}
             target="_blank"

--- a/app/src/features/works/ui/VenueSource.tsx
+++ b/app/src/features/works/ui/VenueSource.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { cn } from '@/shared/lib/cn'
+
+type Props = {
+  /** Libellé affiché, ex. « Théâtre Montparnasse · Paris 14e ». */
+  label: string
+  /** Site officiel du lieu (la « source »). Si absent, le libellé reste en texte simple. */
+  website: string | null
+  /** Classe appliquée au texte/lien (reprend le style de la ligne lieu de chaque carte). */
+  textClassName?: string
+}
+
+// Nom du lieu transformé en lien vers le site officiel (la source) + bouton copier
+// discret. Remplace le lien « Voir sur Offi.fr » quand une source est disponible.
+export default function VenueSource({ label, website, textClassName }: Props) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!website) return
+      try {
+        await navigator.clipboard.writeText(website)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1600)
+      } catch {
+        /* clipboard indisponible : on ignore silencieusement */
+      }
+    },
+    [website],
+  )
+
+  if (!website) {
+    return <span className={textClassName}>{label}</span>
+  }
+
+  return (
+    // stopPropagation sur le pointeur : ne pas déclencher le swipe de la carte Découverte.
+    <span className="inline-flex items-center gap-1" onPointerDown={(e) => e.stopPropagation()}>
+      <a
+        href={website}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(
+          textClassName,
+          'underline-offset-4 transition hover:text-[color:var(--color-accent)] hover:underline',
+        )}
+        title="Site officiel"
+      >
+        {label} <span aria-hidden>↗</span>
+      </a>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={copied ? 'Lien copié' : 'Copier le lien du site officiel'}
+        title={copied ? 'Copié !' : 'Copier le lien'}
+        className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[color:var(--color-text-muted)] transition hover:bg-[rgba(54,39,24,0.08)] hover:text-[color:var(--color-accent)]"
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+      </button>
+    </span>
+  )
+}
+
+function CopyIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  )
+}
+
+function CheckIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  )
+}

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -3,6 +3,7 @@ import type { WorkCardDto } from '@/features/works/dto'
 import { workDirectorLabel, workSectionLabel } from '@/features/works/section'
 import BadgeCategory from '@/features/works/ui/BadgeCategory'
 import WorkImage from '@/features/works/ui/WorkImage'
+import VenueSource from '@/features/works/ui/VenueSource'
 import { formatDateRange, formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
 import { cn } from '@/shared/lib/cn'
 import SurfaceCard from '@/shared/ui/SurfaceCard'
@@ -63,7 +64,13 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
       <div className="flex flex-1 flex-col gap-4 p-4">
         <div className="space-y-2">
           <h3 className="line-clamp-2 text-lg font-semibold tracking-[-0.03em] text-[color:var(--color-text)]">{title}</h3>
-          {venueLine ? <p className="text-sm font-medium text-muted-foreground">{venueLine}</p> : null}
+          {venueLine ? (
+            <VenueSource
+              label={venueLine}
+              website={work?.venueInfo?.website ?? null}
+              textClassName="text-sm font-medium text-muted-foreground"
+            />
+          ) : null}
           {cinemaMeta ? <p className="text-sm font-medium text-muted-foreground">{cinemaMeta}</p> : null}
           {cinemaVenuesLine ? <p className="text-sm text-muted-foreground">{cinemaVenuesLine}</p> : null}
           {director || castNames.length > 0 ? (
@@ -93,14 +100,16 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
         </div>
 
         <div className="mt-auto flex flex-col gap-3 border-t border-[color:var(--color-border)] pt-4">
-          {work?.sourceUrl ? (
+          {/* Fallback Offi : uniquement si le lieu n'a pas de site officiel (sinon la
+              source est portée par le nom du lieu ci-dessus). */}
+          {work?.sourceUrl && !work.venueInfo?.website ? (
             <a
               href={work.sourceUrl}
               target="_blank"
               rel="noreferrer"
               className="text-sm font-semibold text-[color:var(--color-accent)] transition hover:underline"
             >
-              Voir la source
+              Voir sur Offi.fr ↗
             </a>
           ) : null}
 

--- a/app/tests/card-work.test.tsx
+++ b/app/tests/card-work.test.tsx
@@ -91,12 +91,46 @@ describe('CardWork', () => {
         work={{
           ...base,
           section: 'theatre',
-          venueInfo: { name: 'Théâtre de la Huchette', metro: 'Cluny - La Sorbonne', access: 'Accès PMR', phone: null, city: 'Paris 5e' },
+          venueInfo: { name: 'Théâtre de la Huchette', metro: 'Cluny - La Sorbonne', access: 'Accès PMR', phone: null, city: 'Paris 5e', website: null },
         }}
       />,
     )
     expect(screen.getByText(/Cluny - La Sorbonne/)).toBeInTheDocument()
     expect(screen.getByText(/Accès PMR/)).toBeInTheDocument()
+  })
+
+  it('quand le lieu a un site officiel : le nom du lieu est un lien vers la source + bouton copier, sans lien Offi', () => {
+    render(
+      <CardWork
+        work={{
+          ...base,
+          section: 'theatre',
+          venue: 'Théâtre Montparnasse',
+          arrondissement: 'Paris 14e',
+          country: null,
+          year: null,
+          venueInfo: {
+            name: 'Théâtre Montparnasse',
+            metro: null,
+            access: null,
+            phone: null,
+            city: 'Paris 14e',
+            website: 'https://www.theatremontparnasse.com',
+          },
+        }}
+      />,
+    )
+    const link = screen.getByRole('link', { name: /Théâtre Montparnasse/ })
+    expect(link).toHaveAttribute('href', 'https://www.theatremontparnasse.com')
+    expect(screen.getByRole('button', { name: /copier le lien/i })).toBeInTheDocument()
+    // le lien Offi générique disparaît au profit de la source
+    expect(screen.queryByText(/Voir sur Offi\.fr/)).not.toBeInTheDocument()
+  })
+
+  it('sans site officiel : conserve le lien Offi de secours', () => {
+    render(<CardWork work={{ ...base, section: 'theatre', venue: 'Petit Théâtre', venueInfo: null }} />)
+    expect(screen.getByText(/Voir sur Offi\.fr/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /copier le lien/i })).not.toBeInTheDocument()
   })
 
   it('théâtre : affiche le lieu avec l’arrondissement', () => {

--- a/scraper/parsers.py
+++ b/scraper/parsers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from typing import Optional
+from urllib.parse import urlparse
 
 # Regex prix / durée
 PRICE_RE = re.compile(r"(\d+(?:[.,]\d+)?)\s*€")
@@ -326,6 +327,33 @@ def _venue_access_features(text: str) -> Optional[str]:
     return ", ".join(features) or None
 
 
+# Site officiel du lieu : offi marque le lien vers le site du théâtre/salle par
+# rel="external" sur la page lieu (ex. <a rel="external nofollow">www.theatremontparnasse.com</a>).
+# Les autres liens externes sont des boutons de partage (wa.me, bsky, pinterest) ou
+# des bannières promo — on les écarte (rel sans "external" + liste de hosts sociaux).
+_SOCIAL_HOSTS = (
+    "facebook", "instagram", "twitter", "x.com", "youtube", "youtu.be", "tiktok",
+    "linkedin", "pinterest", "wa.me", "whatsapp", "bsky.app", "t.me", "telegram",
+    "snapchat", "threads.net", "google.", "apple.com", "offi.fr",
+)
+
+
+def extract_official_website(soup) -> Optional[str]:
+    """URL du site officiel du lieu (lien rel="external" non social), ou None."""
+    for a in soup.find_all("a", href=True):
+        rel = " ".join(a.get("rel") or []).lower()
+        if "external" not in rel:
+            continue
+        href = (a.get("href") or "").strip()
+        if not href.startswith(("http://", "https://")):
+            continue
+        host = urlparse(href).netloc.lower()
+        if any(s in host for s in _SOCIAL_HOSTS):
+            continue
+        return href
+    return None
+
+
 def extract_venue(soup, source_url: str, kind: str) -> Optional[dict]:
     """Extrait les infos d'une page lieu (BeautifulSoup) → dict, ou None si pas de nom."""
     offi_id = offi_id_from_url(source_url)
@@ -390,6 +418,7 @@ def extract_venue(soup, source_url: str, kind: str) -> Optional[dict]:
         "metro": metro,
         "access": access,
         "image": image,
+        "website": extract_official_website(soup),
         "source_url": source_url,
     }
 

--- a/scraper/tests/test_parsers.py
+++ b/scraper/tests/test_parsers.py
@@ -211,6 +211,11 @@ class VenueTests(unittest.TestCase):
             '<span itemprop="telephone">01.42.50.23.32 (tlj 13h30-21h)</span>'
             '<p>Métro : Commerce Accès PMR, salle climatisée</p>'
             '<meta property="og:image" content="https://files.offi.fr/lieu/3113/images/1000/x.jpg">'
+            # Boutons de partage (rel external mais hosts sociaux) → écartés
+            '<a rel="external" href="https://pinterest.com/pin/create/x">Pinterest</a>'
+            '<a href="https://wa.me/?text=x">WhatsApp</a>'
+            # Site officiel du lieu → retenu
+            '<a rel="external nofollow" href="http://www.lechaplin.fr">www.lechaplin.fr</a>'
         )
         v = parsers.extract_venue(_soup(html), "https://www.offi.fr/cinema/le-chaplin-3113.html", "cinema")
         self.assertEqual(v["offi_id"], 3113)
@@ -222,6 +227,7 @@ class VenueTests(unittest.TestCase):
         self.assertEqual(v["metro"], "Commerce")  # coupé à la rubrique suivante
         self.assertEqual(v["access"], "Accès PMR, Espace climatisé")
         self.assertTrue(v["image"].endswith("x.jpg"))
+        self.assertEqual(v["website"], "http://www.lechaplin.fr")  # site officiel, pas le partage
 
     def test_extract_venue_requires_name(self):
         self.assertIsNone(parsers.extract_venue(_soup("<div>no h1</div>"), "https://www.offi.fr/cinema/x-1.html", "cinema"))


### PR DESCRIPTION
## Pourquoi
On renvoyait toujours vers Offi.fr — pauvre. On surface maintenant **le lien à la source** : le site officiel du lieu (théâtre, salle, musée…).

## Ce que ça change (UX)
- Le **nom du lieu** (ligne 📍) devient un **hyperlien vers le site officiel** (nouvel onglet).
- Un **bouton copier discret** à côté permet de copier ce lien.
- Le lien générique « Voir sur Offi.fr » **disparaît** quand une source existe ; il reste **en secours** uniquement pour le cinéma (un film = plusieurs salles, pas de site unique) ou un lieu sans site officiel publié.

## Comment on récupère la source
Offi marque le site officiel du lieu par un lien `rel="external"` sur la **page lieu** (vérifié sur théâtre / concert / expo). Les boutons de partage (wa.me, bsky, pinterest) et bannières promo sont écartés (filtre `rel` + hosts sociaux).

## Détail technique
- **scraper** : `parsers.extract_official_website` + champ `website` dans `extract_venue` (+ test).
- **db** : `Venue.website` (migration `add_venue_website`, appliquée sur Neon) → DTO `venueInfo.website`.
- **ui** : composant client `VenueSource` (lien + copier, `stopPropagation` pour ne pas déclencher le swipe), branché dans `CardWork` (Découverte) et `WorkSummaryCard` (modal /likes).
- **backfill** :
  - `backfill-venue-websites.ts` : remplit `website` sur les lieux déjà en base → **201/253** lieux ont un site officiel (52 n'en publient pas).
  - `backfill-venues.ts` généralisé aux sections « lieu » (expo/concert/visite/enfants) → rattache ces œuvres à leur lieu (donc à leur source).

## Tests
`scraper` unittest + `app` vitest (114) verts ; `tsc` + `eslint` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
