### PR TITLE
feat: découvrir la page dédiée du spectacle sur le site du lieu

### DIFF
--- a/app/scripts/backfill-official-url-from-venue.ts
+++ b/app/scripts/backfill-official-url-from-venue.ts
@@ -1,0 +1,117 @@
+// Backfill Work.officialUrl en DÉCOUVRANT la page dédiée sur le site du lieu.
+//
+// Offi n'expose pas de lien profond pour le théâtre (et certains autres). Mais le
+// site du lieu liste ses spectacles courants. On inspecte la home du lieu, on
+// matche chaque titre de façon conservatrice (scraper/discover.py) et — seulement si
+// l'URL répond en 200 — on l'enregistre. Mieux vaut aucun lien qu'un mauvais.
+//
+// Re-runnable : ne traite que les œuvres venue-based sans officialUrl dont le lieu a
+// un site. Couverture partielle attendue (spectacles non listés sur la home, sites
+// qui bloquent/SSL invalide).
+//
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local \
+//   scripts/backfill-official-url-from-venue.ts [sections] [maxVenues]
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { prisma } from '@/server/db'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const scraperDir = path.resolve(here, '../../scraper')
+const PY = path.join(scraperDir, '.venv/bin/python')
+const CLI = path.join(scraperDir, 'discover.py')
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+
+const DEFAULT_SECTIONS = ['theatre', 'exposition', 'concert', 'visite', 'enfants']
+const sections = (process.argv[2] ? process.argv[2].split(',') : DEFAULT_SECTIONS).map((s) => s.trim()).filter(Boolean)
+const maxVenues = Number(process.argv[3] ?? 1000)
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function fetchPage(url: string): Promise<{ html: string; finalUrl: string } | null> {
+  try {
+    const res = await fetch(url, { headers: { 'User-Agent': UA }, redirect: 'follow', signal: AbortSignal.timeout(15_000) })
+    if (!res.ok) return null
+    return { html: await res.text(), finalUrl: res.url || url }
+  } catch {
+    return null // 403, SSL invalide, DNS… → on saute ce lieu
+  }
+}
+
+// Vérifie qu'une URL découverte répond (évite d'enregistrer un lien mort).
+async function isLive(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { headers: { 'User-Agent': UA }, redirect: 'follow', signal: AbortSignal.timeout(12_000) })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+function matchTitles(baseUrl: string, html: string, titles: string[]): Record<string, string> {
+  const res = spawnSync(PY, [CLI, baseUrl], {
+    input: JSON.stringify({ html, titles }),
+    encoding: 'utf-8',
+    cwd: scraperDir,
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 20_000,
+    killSignal: 'SIGKILL',
+  })
+  if (res.status !== 0 || !res.stdout) return {}
+  try {
+    return JSON.parse(res.stdout)?.matches ?? {}
+  } catch {
+    return {}
+  }
+}
+
+async function main() {
+  // Œuvres sans officialUrl, dont le lieu a un site, groupées par lieu.
+  const works = await prisma.work.findMany({
+    where: { officialUrl: null, section: { in: sections }, venue_ref: { website: { not: null } } },
+    select: { id: true, title: true, venueId: true, venue_ref: { select: { website: true } } },
+  })
+
+  const byVenue = new Map<string, { website: string; items: { id: string; title: string }[] }>()
+  for (const w of works) {
+    const website = w.venue_ref?.website
+    if (!w.venueId || !website) continue
+    const g = byVenue.get(w.venueId) ?? { website, items: [] }
+    g.items.push({ id: w.id, title: w.title })
+    byVenue.set(w.venueId, g)
+  }
+
+  const venues = [...byVenue.entries()].slice(0, maxVenues)
+  let venuesFetched = 0
+  let matched = 0
+  let live = 0
+
+  for (const [, group] of venues) {
+    const page = await fetchPage(group.website)
+    if (!page) continue
+    venuesFetched += 1
+
+    const titles = group.items.map((i) => i.title)
+    const matches = matchTitles(page.finalUrl, page.html, titles)
+
+    for (const item of group.items) {
+      const url = matches[item.title]
+      if (!url) continue
+      matched += 1
+      if (!(await isLive(url))) continue
+      live += 1
+      await prisma.work.update({ where: { id: item.id }, data: { officialUrl: url } })
+    }
+    await sleep(400) // throttle poli
+  }
+
+  console.log(
+    JSON.stringify({ sections, venuesCandidates: byVenue.size, venuesFetched, matched, written: live }),
+  )
+}
+
+main()
+  .catch((error) => {
+    console.error('[backfill-official-url-from-venue]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/scraper/discover.py
+++ b/scraper/discover.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""Découverte des pages dédiées d'un spectacle sur le site officiel du lieu.
+
+Offi n'expose pas de lien profond pour le théâtre. Mais le site du lieu liste ses
+spectacles courants avec, partout, le titre dans le slug/texte du lien — sans schéma
+d'URL commun (theatremontparnasse.com/spectacle/<slug>/, comediedeparis.com/<slug>…).
+
+On ne *fabrique* donc pas l'URL : on *découvre* les liens de la page du lieu et on
+matche chaque titre de façon **conservatrice** (mieux vaut aucun lien qu'un mauvais).
+Fonctions pures (HTML en entrée) → testables sans réseau.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+# Mots vides FR/EN : exclus des tokens de matching (bruit, pas discriminants).
+_STOP = {
+    "les", "des", "une", "que", "qui", "pour", "sur", "avec", "dans", "the", "and",
+    "nen", "tout", "tous", "toute", "aux", "par", "ses", "son", "sa", "mes", "vos",
+    "nos", "leur", "ce", "cet", "cette", "est", "ne", "pas", "plus", "moins",
+}
+# Segments de navigation (jamais une fiche spectacle) : on les écarte d'office.
+_NAV = {
+    "contact", "acces", "infos", "info", "billetterie", "reservation", "reservations",
+    "mentions", "mentions-legales", "cookies", "newsletter", "histoire", "agenda",
+    "programmation", "programme", "saison", "categorie", "categorie-spectacle",
+    "spectacles", "actualites", "presse", "partenaires", "mecenat", "faq", "plan",
+    "accueil", "home", "boutique", "offres", "scolaires", "groupes", "accessibilite",
+}
+
+
+def slugify(value: str) -> str:
+    value = unicodedata.normalize("NFKD", value or "").encode("ascii", "ignore").decode()
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def tokens(value: str) -> set[str]:
+    return {t for t in slugify(value).split("-") if len(t) >= 3 and t not in _STOP}
+
+
+def _candidates(soup, base_url: str) -> list[tuple[str, str, set[str]]]:
+    """Liens internes (url, slug du dernier segment, tokens slug+texte du lien)."""
+    host = urlparse(base_url).netloc
+    out: list[tuple[str, str, set[str]]] = []
+    seen: set[str] = set()
+    for a in soup.find_all("a", href=True):
+        url = urljoin(base_url, a["href"])
+        parsed = urlparse(url)
+        if parsed.netloc != host:
+            continue
+        url = parsed._replace(query="", fragment="").geturl()
+        path = parsed.path.strip("/")
+        if not path or url in seen:
+            continue
+        segs = [s for s in path.split("/") if s]
+        last = segs[-1]
+        if last in _NAV or segs[0] in _NAV:
+            continue
+        seen.add(url)
+        cslug = slugify(last)
+        ctoks = tokens(last) | tokens(a.get_text(" ", strip=True))
+        out.append((url, cslug, ctoks))
+    return out
+
+
+def match_title(title: str, candidates: list[tuple[str, str, set[str]]]) -> Optional[str]:
+    """URL la plus probable pour ce titre, ou None si rien d'assez sûr.
+
+    Conservateur, par ordre de confiance :
+      1. slug du titre == slug candidat (égalité exacte) → sûr, même titre court ;
+      2. slug du titre (≥ 8 car.) contenu dans le slug candidat ;
+      3. ≥ 2 tokens communs couvrant ≥ 60 % du titre (titres ≥ 2 tokens).
+    Sinon, rien (mieux vaut aucun lien qu'un mauvais)."""
+    tslug = slugify(title)
+    tt = tokens(title)
+    best_url: Optional[str] = None
+    best_score = 0.0
+    for url, cslug, ctoks in candidates:
+        score = 0.0
+        if tslug and tslug == cslug:
+            score = 1.0
+        elif len(tslug) >= 8 and tslug in cslug:
+            score = 1.0
+        elif len(tt) >= 2:
+            inter = tt & ctoks
+            if len(inter) >= 2:
+                recall = len(inter) / len(tt)
+                if recall >= 0.6:
+                    score = recall
+        if score > best_score:
+            best_score, best_url = score, url
+    return best_url if best_score >= 0.6 else None
+
+
+def match_titles(html: str, base_url: str, titles: list[str]) -> dict[str, str]:
+    """Map {titre: url} pour les titres matchés avec confiance."""
+    soup = BeautifulSoup(html or "", "html.parser")
+    cands = _candidates(soup, base_url)
+    result: dict[str, str] = {}
+    for title in titles:
+        url = match_title(title, cands)
+        if url:
+            result[title] = url
+    return result
+
+
+def _main() -> None:
+    import json
+    import sys
+
+    base_url = sys.argv[1] if len(sys.argv) > 1 else ""
+    payload = json.loads(sys.stdin.read() or "{}")
+    matches = match_titles(payload.get("html", ""), base_url, payload.get("titles", []))
+    print(json.dumps({"matches": matches}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    _main()

--- a/scraper/tests/test_discover.py
+++ b/scraper/tests/test_discover.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from scraper import discover
+
+
+# Extrait simplifié d'une home de théâtre (cas réels : Montparnasse).
+HTML = """
+<a href="/spectacle/tango/">¡Tango!</a>
+<a href="/spectacle/ancien-malade-des-hopitaux-de-paris/">Ancien malade</a>
+<a href="/spectacle/la-femme-qui-naimait-pas-rabbi-jacob-3/">La Femme...</a>
+<a href="/histoire/">Notre histoire</a>
+<a href="/contact-et-reservation/">Réserver</a>
+<a href="https://twitter.com/x">Twitter</a>
+"""
+BASE = "https://www.theatremontparnasse.com"
+
+
+class SlugifyTests(unittest.TestCase):
+    def test_strips_accents_and_punct(self):
+        self.assertEqual(discover.slugify("¡Tango!"), "tango")
+        self.assertEqual(discover.slugify("Ancien malade des hôpitaux"), "ancien-malade-des-hopitaux")
+
+    def test_tokens_drop_short_and_stopwords(self):
+        self.assertEqual(discover.tokens("La Femme qui n'aimait pas"), {"femme", "aimait"})
+
+
+class MatchTitlesTests(unittest.TestCase):
+    def test_matches_known_shows(self):
+        m = discover.match_titles(
+            HTML, BASE, ["¡Tango!", "Ancien malade des hôpitaux de Paris", "La Femme qui n'aimait pas Rabbi Jacob"]
+        )
+        self.assertEqual(m["¡Tango!"], f"{BASE}/spectacle/tango/")
+        self.assertTrue(m["Ancien malade des hôpitaux de Paris"].endswith("/spectacle/ancien-malade-des-hopitaux-de-paris/"))
+        self.assertIn("rabbi-jacob", m["La Femme qui n'aimait pas Rabbi Jacob"])
+
+    def test_short_title_not_matched(self):
+        # « Art » = 1 token → trop court, on n'invente pas de lien.
+        self.assertEqual(discover.match_titles(HTML, BASE, ["« Art »"]), {})
+
+    def test_absent_show_not_matched(self):
+        self.assertEqual(discover.match_titles(HTML, BASE, ["The Loop"]), {})
+
+    def test_nav_pages_excluded(self):
+        # "Notre histoire" ne doit pas être pris comme un spectacle.
+        self.assertEqual(discover.match_titles(HTML, BASE, ["Le Porteur d'histoire"]), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Pourquoi
Suite de #57/#58. Le théâtre n'a aucun lien externe sur Offi, mais **le site du lieu liste ses spectacles** (`theatremontparnasse.com/spectacle/tango/`…). On va donc **chercher la page dédiée à la source**.

## L'idée (validée empiriquement)
Aucun schéma d'URL commun entre sites (`/spectacle/<slug>/`, `/project/<slug>/`, slug à la racine…). On ne *fabrique* donc pas l'URL : on **inspecte la home du lieu** et on **matche chaque titre** au bon lien (le titre est dans le slug/texte partout).

Matching **conservateur** (mieux vaut aucun lien qu'un mauvais) :
1. égalité de slug exacte (sûr, même titre court) ;
2. slug du titre (≥8 car.) contenu dans le slug candidat ;
3. ≥2 tokens significatifs communs couvrant ≥60 % du titre.
Pages de navigation exclues (contact, histoire, billetterie…), titres trop courts ignorés, et **l'URL doit répondre en 200** avant enregistrement.

Smoke-test (4 lieux) : 9/9 corrects sur 3 schémas d'URL différents, 0 faux positif.

## Limites assumées
- Couverture **partielle** : seuls les spectacles **listés sur la home** sont trouvés (archivés non) ; certains sites bloquent (403) ou ont un certificat SSL invalide → ignorés.
- Coverage finale communiquée après le run.

## Technique
- `scraper/discover.py` : `slugify` / `tokens` / `match_titles` (fonctions pures, testées) + CLI.
- `app/scripts/backfill-official-url-from-venue.ts` : groupe les œuvres sans `officialUrl` par lieu, fetch la home, matche, vérifie 200, écrit `officialUrl`. Re-runnable.
- **Aucun changement de schéma ni d'UI** : réutilise `Work.officialUrl` + le titre-lien de #58.

## Tests
scraper unittest (53, dont `test_discover`) ✓ · vitest ✓ · tsc ✓ · eslint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
