### PR TITLE
feat: onglet Streaming dans Découverte (films par plateforme, TMDB)

### DIFF
--- a/app/prisma/migrations/20260609190000_add_work_platforms/migration.sql
+++ b/app/prisma/migrations/20260609190000_add_work_platforms/migration.sql
@@ -1,0 +1,3 @@
+-- Plateformes de streaming (abonnement) où le film est dispo + index GIN pour le filtre.
+ALTER TABLE "Work" ADD COLUMN "platforms" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+CREATE INDEX "Work_platforms_idx" ON "Work" USING GIN ("platforms");

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -92,6 +92,7 @@ model Work {
   currency  String?        // devise du prix : "EUR"
   cinemaVenueCount Int?    // nb de salles où le film est programmé (cinéma)
   cinemaVenues String[]    // échantillon de noms de salles (cinéma)
+  platforms String[]       // plateformes de streaming (abonnement) où le film est dispo : "Netflix", "Disney+"…
   officialUrl String?      // lien externe dédié de la fiche (rel="external") : site de l'expo, page du concert…
   sourceUrl String    @unique
 
@@ -108,6 +109,7 @@ model Work {
 
   @@index([section, createdAt])
   @@index([venueId])
+  @@index([platforms], type: Gin) // filtre streaming par plateforme (hasSome)
 }
 
 // Lieu (théâtre ou cinéma) — catalogue avec infos pratiques scrapées sur offi.

--- a/app/scripts/ingest-tmdb-streaming.ts
+++ b/app/scripts/ingest-tmdb-streaming.ts
@@ -1,0 +1,146 @@
+// Ingestion du catalogue « streaming » depuis TMDB (données FR, propulsées par
+// JustWatch). Pour chaque plateforme cible, on liste via /discover/movie les films
+// disponibles sans surcoût (abonnement/gratuit/ads, PAS location/achat), on agrège
+// les plateformes par film, et on upsert des Work(section='streaming').
+//
+// Pas d'appel détail par film (catalogue large → rapide) : on garde ce que /discover
+// fournit (titre, synopsis, affiche, année, genres). Director/durée restent nuls.
+//
+// Idempotent : re-runnable. Les films qui ont quitté toutes les plateformes voient
+// leur `platforms` vidé (→ masqués côté Découverte) sans suppression (réactions
+// préservées).
+//
+// Pré-requis : TMDB_API_KEY (clé v3) dans l'env.
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local \
+//   scripts/ingest-tmdb-streaming.ts [maxPagesPerProvider]
+import { prisma } from '@/server/db'
+
+const API = 'https://api.themoviedb.org/3'
+const IMG = 'https://image.tmdb.org/t/p/w500'
+const KEY = process.env.TMDB_API_KEY
+const REGION = 'FR'
+const LANG = 'fr-FR'
+const MONETIZATION = 'flatrate|free|ads' // inclus sans surcoût ; exclut rent/buy
+const maxPages = Number(process.argv[2] ?? 20)
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+const norm = (s: string) => s.toLowerCase().replace(/\s+/g, ' ').trim()
+
+// Plateformes cibles : nom canonique (affiché/stocké) + alias TMDB possibles.
+const TARGETS: { canonical: string; aliases: string[] }[] = [
+  { canonical: 'Netflix', aliases: ['netflix'] },
+  { canonical: 'Prime Video', aliases: ['amazon prime video', 'prime video'] },
+  { canonical: 'Disney+', aliases: ['disney plus', 'disney+'] },
+  { canonical: 'Canal+', aliases: ['canal+', 'canal plus', 'canalplus'] },
+  { canonical: 'Arte', aliases: ['arte'] },
+  { canonical: 'France TV', aliases: ['france tv', 'france.tv', 'francetv'] },
+  { canonical: 'TF1+', aliases: ['tf1+', 'mytf1', 'tf1 plus'] },
+  { canonical: 'M6+', aliases: ['m6+', '6play', 'm6 plus'] },
+]
+
+type Movie = { id: number; title: string; overview: string; poster_path: string | null; release_date: string; genre_ids: number[] }
+
+async function tmdb(path: string, params: Record<string, string> = {}): Promise<any> {
+  const qs = new URLSearchParams({ api_key: KEY!, language: LANG, ...params })
+  const res = await fetch(`${API}${path}?${qs}`, { signal: AbortSignal.timeout(20_000) })
+  if (!res.ok) throw new Error(`TMDB ${path} → HTTP ${res.status}`)
+  return res.json()
+}
+
+async function resolveProviderIds(): Promise<Map<number, string>> {
+  const data = await tmdb('/watch/providers/movie', { watch_region: REGION })
+  const ids = new Map<number, string>() // provider_id → nom canonique
+  for (const p of data.results ?? []) {
+    const name = norm(p.provider_name)
+    const target = TARGETS.find((t) => t.aliases.includes(name))
+    if (target) ids.set(p.provider_id, target.canonical)
+  }
+  return ids
+}
+
+async function genreMap(): Promise<Map<number, string>> {
+  const data = await tmdb('/genre/movie/list')
+  return new Map<number, string>((data.genres ?? []).map((g: { id: number; name: string }) => [g.id, g.name.toLowerCase()]))
+}
+
+async function main() {
+  if (!KEY) throw new Error('TMDB_API_KEY manquant (env). Ajoute-le dans app/.env.local')
+
+  const providerIds = await resolveProviderIds()
+  if (providerIds.size === 0) throw new Error('Aucune plateforme cible trouvée dans la liste TMDB FR')
+  console.log(`[tmdb] plateformes résolues: ${[...new Set(providerIds.values())].join(', ')}`)
+  const genres = await genreMap()
+
+  // movie id → { film, plateformes }
+  const catalog = new Map<number, { movie: Movie; platforms: Set<string> }>()
+
+  for (const [providerId, canonical] of providerIds) {
+    let page = 1
+    let totalPages = 1
+    do {
+      const data = await tmdb('/discover/movie', {
+        watch_region: REGION,
+        with_watch_monetization_types: MONETIZATION,
+        with_watch_providers: String(providerId),
+        sort_by: 'popularity.desc',
+        page: String(page),
+      })
+      totalPages = Math.min(data.total_pages ?? 1, maxPages)
+      for (const m of (data.results ?? []) as Movie[]) {
+        if (!m.title) continue
+        const entry = catalog.get(m.id) ?? { movie: m, platforms: new Set<string>() }
+        entry.platforms.add(canonical)
+        catalog.set(m.id, entry)
+      }
+      page += 1
+      await sleep(120) // throttle poli (TMDB ~50 req/s, on reste loin)
+    } while (page <= totalPages)
+    console.log(`[tmdb] ${canonical}: catalogue cumulé ${catalog.size} films`)
+  }
+
+  const runStart = new Date()
+  const records = [...catalog.values()]
+  const CONC = 25
+  let imported = 0
+  for (let i = 0; i < records.length; i += CONC) {
+    const chunk = records.slice(i, i + CONC)
+    await Promise.all(
+      chunk.map(({ movie, platforms }) => {
+        const year = movie.release_date ? Number(movie.release_date.slice(0, 4)) || null : null
+        const category = movie.genre_ids?.map((g) => genres.get(g)).filter(Boolean).slice(0, 2).join(', ') || null
+        const data = {
+          title: movie.title,
+          section: 'streaming',
+          category,
+          description: movie.overview?.trim() || null,
+          imageUrl: movie.poster_path ? `${IMG}${movie.poster_path}` : null,
+          year: year && year >= 1880 && year <= 2100 ? year : null,
+          platforms: [...platforms].sort(),
+          officialUrl: `https://www.themoviedb.org/movie/${movie.id}/watch?locale=${REGION}`,
+        }
+        const sourceUrl = `https://www.themoviedb.org/movie/${movie.id}`
+        return prisma.work.upsert({
+          where: { sourceUrl },
+          create: { ...data, sourceUrl },
+          update: data,
+        })
+      }),
+    )
+    imported += chunk.length
+  }
+
+  // Masque les films qui ont quitté toutes les plateformes (pas vus ce run) sans
+  // supprimer (réactions préservées) : platforms vidé → exclus de la Découverte.
+  const stale = await prisma.work.updateMany({
+    where: { section: 'streaming', updatedAt: { lt: runStart }, NOT: { platforms: { isEmpty: true } } },
+    data: { platforms: [] },
+  })
+
+  console.log(JSON.stringify({ films: catalog.size, imported, staleCleared: stale.count }))
+}
+
+main()
+  .catch((error) => {
+    console.error('[ingest-tmdb-streaming]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/app/src/app/discover/page.tsx
+++ b/app/src/app/discover/page.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from 'next'
 import { requireSessionUserOrRedirect } from '@/features/auth/server/session'
 import { DEFAULT_WORK_SECTION, WORK_SECTION_LABELS, WORK_SECTION_VALUES, type WorkSection } from '@/features/works/section'
-import { listDiscoverWorks } from '@/features/works/server/queries'
+import { listDiscoverWorks, listStreamingPlatforms } from '@/features/works/server/queries'
 import SwipeDeck from '@/features/works/ui/SwipeDeck'
+import StreamingPlatformFilter from '@/features/works/ui/StreamingPlatformFilter'
 import SegmentedControl from '@/shared/ui/SegmentedControl'
 
 export const metadata: Metadata = {
@@ -17,6 +18,7 @@ export const fetchCache = 'force-no-store'
 type DiscoverPageProps = {
   searchParams?: Promise<{
     section?: string | string[]
+    platforms?: string | string[]
   }>
 }
 
@@ -25,16 +27,36 @@ function resolveSection(value: string | string[] | undefined): WorkSection {
   return candidate && WORK_SECTION_VALUES.includes(candidate as WorkSection) ? (candidate as WorkSection) : DEFAULT_WORK_SECTION
 }
 
+function resolvePlatforms(value: string | string[] | undefined): string[] {
+  const raw = Array.isArray(value) ? value.join(',') : (value ?? '')
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
 export default async function DiscoverPage({ searchParams }: DiscoverPageProps = {}) {
   const sessionUser = await requireSessionUserOrRedirect()
 
   const resolvedSearchParams = searchParams ? await searchParams : undefined
   const section = resolveSection(resolvedSearchParams?.section)
-  const works = await listDiscoverWorks({ userId: sessionUser.id, per: 200, section })
+  const isStreaming = section === 'streaming'
+  // Le filtre plateformes ne s'applique que sur l'onglet streaming.
+  const selectedPlatforms = isStreaming ? resolvePlatforms(resolvedSearchParams?.platforms) : []
+
+  const [works, availablePlatforms] = await Promise.all([
+    listDiscoverWorks({
+      userId: sessionUser.id,
+      per: 200,
+      section,
+      platforms: selectedPlatforms.length ? selectedPlatforms : undefined,
+    }),
+    isStreaming ? listStreamingPlatforms() : Promise.resolve([]),
+  ])
 
   return (
     <div className="page-shell">
-      <h1 className="sr-only">Découvertes — théâtre et cinéma à Paris</h1>
+      <h1 className="sr-only">Découvertes — sorties à Paris et films en streaming</h1>
       <SegmentedControl
         ariaLabel="Sections culturelles"
         value={section}
@@ -45,6 +67,8 @@ export default async function DiscoverPage({ searchParams }: DiscoverPageProps =
           href: `/discover?section=${s}`,
         }))}
       />
+
+      {isStreaming ? <StreamingPlatformFilter available={availablePlatforms} selected={selectedPlatforms} /> : null}
 
       <SwipeDeck items={works.items} totalCount={works.total} />
     </div>

--- a/app/src/features/reactions/ui/LikeDetailModal.tsx
+++ b/app/src/features/reactions/ui/LikeDetailModal.tsx
@@ -39,6 +39,16 @@ export default function LikeDetailModal({ work, fallbackTitle, friends, bucket, 
   const title = work?.title ?? fallbackTitle
   const availability = formatAvailability(work?.availability ?? null)
   const soldOut = work?.availability === 'SoldOut' || work?.availability === 'OutOfStock'
+  const isStreaming = work?.section === 'streaming'
+  // CTA : « Où regarder » (streaming, vers la page where-to-watch) sinon réservation Offi.
+  const ctaHref = isStreaming ? work?.officialUrl ?? work?.sourceUrl ?? null : work?.sourceUrl ?? null
+  const ctaLabel = isStreaming
+    ? 'Où regarder ↗'
+    : soldOut
+      ? 'Complet — voir sur Offi.fr ↗'
+      : availability
+        ? 'Réserver des billets ↗'
+        : 'Voir sur Offi.fr ↗'
   const venueMetro = work?.venueInfo?.metro?.trim()
   const venueAccess = work?.venueInfo?.access?.trim()
   const venuePhone = work?.venueInfo?.phone?.trim()
@@ -93,16 +103,16 @@ export default function LikeDetailModal({ work, fallbackTitle, friends, bucket, 
                 </p>
               ) : null}
 
-              {/* Réserver */}
-              {work?.sourceUrl ? (
+              {/* Réserver / Où regarder */}
+              {ctaHref ? (
                 <a
-                  href={work.sourceUrl}
+                  href={ctaHref}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`btn ${soldOut ? 'btn-secondary' : 'btn-primary'} w-full justify-center`}
-                  aria-disabled={soldOut || undefined}
+                  className={`btn ${soldOut && !isStreaming ? 'btn-secondary' : 'btn-primary'} w-full justify-center`}
+                  aria-disabled={(soldOut && !isStreaming) || undefined}
                 >
-                  {soldOut ? 'Complet — voir sur Offi.fr ↗' : availability ? 'Réserver des billets ↗' : 'Voir sur Offi.fr ↗'}
+                  {ctaLabel}
                 </a>
               ) : null}
 

--- a/app/src/features/works/dto.ts
+++ b/app/src/features/works/dto.ts
@@ -24,6 +24,7 @@ export const workCardSelect = {
   currency: true,
   cinemaVenueCount: true,
   cinemaVenues: true,
+  platforms: true,
   officialUrl: true,
   sourceUrl: true,
   venue_ref: {
@@ -56,6 +57,7 @@ export type WorkCardDto = {
   currency: string | null
   cinemaVenueCount: number | null
   cinemaVenues: string[]
+  platforms: string[]
   officialUrl: string | null
   sourceUrl: string | null
   venueInfo: {
@@ -92,6 +94,7 @@ export function mapWorkToCardDto(work: WorkCardRecord): WorkCardDto {
     currency: work.currency,
     cinemaVenueCount: work.cinemaVenueCount,
     cinemaVenues: work.cinemaVenues,
+    platforms: work.platforms,
     officialUrl: work.officialUrl,
     sourceUrl: work.sourceUrl,
     venueInfo: work.venue_ref

--- a/app/src/features/works/schemas.ts
+++ b/app/src/features/works/schemas.ts
@@ -10,6 +10,18 @@ export const listDiscoverWorksParamsSchema = z.object({
       .transform((value) => (value ? new Date(value) : undefined)),
   category: z.string().trim().min(1).optional(),
   section: z.enum(WORK_SECTION_VALUES).optional(),
+  // Filtre plateformes streaming (CSV "Netflix,Disney+" ou tableau).
+  platforms: z
+    .preprocess(
+      (value) =>
+        Array.isArray(value)
+          ? value
+          : typeof value === 'string'
+            ? value.split(',').map((s) => s.trim()).filter(Boolean)
+            : undefined,
+      z.array(z.string().min(1)).max(40).optional(),
+    )
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
 })
 
 export type ListDiscoverWorksParams = z.infer<typeof listDiscoverWorksParamsSchema>

--- a/app/src/features/works/section.ts
+++ b/app/src/features/works/section.ts
@@ -1,4 +1,4 @@
-export const WORK_SECTION_VALUES = ['theatre', 'cinema', 'exposition', 'concert', 'visite', 'enfants'] as const
+export const WORK_SECTION_VALUES = ['theatre', 'cinema', 'streaming', 'exposition', 'concert', 'visite', 'enfants'] as const
 
 export type WorkSection = (typeof WORK_SECTION_VALUES)[number]
 
@@ -8,6 +8,7 @@ export const DEFAULT_WORK_SECTION: WorkSection = 'theatre'
 export const WORK_SECTION_LABELS: Record<WorkSection, string> = {
   theatre: 'Théâtre',
   cinema: 'Cinéma',
+  streaming: 'Streaming',
   exposition: 'Exposition',
   concert: 'Concert',
   visite: 'Visite',
@@ -41,6 +42,7 @@ export function inferWorkSectionFromUrl(url: string | null | undefined): WorkSec
 export function workDirectorLabel(section: string | null | undefined): string {
   switch (section) {
     case 'cinema':
+    case 'streaming':
     case 'exposition':
       return 'De'
     case 'concert':

--- a/app/src/features/works/server/queries.ts
+++ b/app/src/features/works/server/queries.ts
@@ -11,7 +11,7 @@ type ListDiscoverWorksInput = Partial<ListDiscoverWorksParams> & {
 }
 
 export async function listDiscoverWorks(input: ListDiscoverWorksInput = {}) {
-  const { per, since, category, section } = listDiscoverWorksParamsSchema.parse(input)
+  const { per, since, category, section, platforms } = listDiscoverWorksParamsSchema.parse(input)
   const where: Prisma.WorkWhereInput = {
     OR: [{ endDate: null }, { endDate: { gte: getParisTodayStart() } }],
   }
@@ -26,6 +26,14 @@ export async function listDiscoverWorks(input: ListDiscoverWorksInput = {}) {
 
   if (section) {
     where.section = section
+  }
+
+  // Streaming : ne montrer que les films réellement dispo (≥ 1 plateforme) et
+  // appliquer le filtre plateformes éventuel (sinon le filtre s'applique tel quel).
+  if (section === 'streaming') {
+    where.platforms = platforms ? { hasSome: platforms } : { isEmpty: false }
+  } else if (platforms) {
+    where.platforms = { hasSome: platforms }
   }
 
   if (input.userId) {
@@ -46,4 +54,14 @@ export async function listDiscoverWorks(input: ListDiscoverWorksInput = {}) {
     total,
     items: works.map(mapWorkToCardDto),
   }
+}
+
+// Plateformes de streaming présentes dans le catalogue (options du filtre Découverte).
+export async function listStreamingPlatforms(): Promise<string[]> {
+  const rows = await prisma.$queryRaw<{ p: string }[]>`
+    SELECT DISTINCT unnest(platforms) AS p
+    FROM "Work"
+    WHERE section = 'streaming'
+    ORDER BY p`
+  return rows.map((r) => r.p)
 }

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -125,6 +125,22 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
           <p className="text-xs text-[color:var(--color-text-muted)]">🎬 {cinemaVenuesLine}</p>
         ) : null}
 
+        {work.platforms && work.platforms.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
+              📺 Dispo sur
+            </span>
+            {work.platforms.map((p) => (
+              <span
+                key={p}
+                className="rounded-full bg-[rgba(54,39,24,0.06)] px-2.5 py-0.5 text-xs font-medium text-[color:var(--color-text)]"
+              >
+                {p}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
         {hasFacts ? (
           <div className="flex flex-wrap items-center gap-2">
             {durationLabel ? (

--- a/app/src/features/works/ui/StreamingPlatformFilter.tsx
+++ b/app/src/features/works/ui/StreamingPlatformFilter.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link'
+
+type Props = {
+  /** Plateformes disponibles dans le catalogue. */
+  available: string[]
+  /** Plateformes actuellement sélectionnées. */
+  selected: string[]
+}
+
+function hrefFor(platforms: string[]) {
+  const base = '/discover?section=streaming'
+  return platforms.length ? `${base}&platforms=${encodeURIComponent(platforms.join(','))}` : base
+}
+
+// Filtre plateformes de l'onglet Streaming : chaque puce ajoute/retire sa plateforme
+// du filtre (état porté par l'URL → re-rendu serveur du deck). « Toutes » réinitialise.
+export default function StreamingPlatformFilter({ available, selected }: Props) {
+  if (available.length === 0) return null
+  const selectedSet = new Set(selected)
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Filtrer par plateforme">
+      <Link
+        href={hrefFor([])}
+        className={`rounded-full px-3 py-1 text-xs font-medium transition ${
+          selectedSet.size === 0
+            ? 'bg-[color:var(--color-accent)] text-white'
+            : 'bg-[rgba(54,39,24,0.06)] text-[color:var(--color-text)] hover:bg-[rgba(54,39,24,0.12)]'
+        }`}
+      >
+        Toutes
+      </Link>
+      {available.map((platform) => {
+        const active = selectedSet.has(platform)
+        const next = active ? selected.filter((p) => p !== platform) : [...selected, platform]
+        return (
+          <Link
+            key={platform}
+            href={hrefFor(next)}
+            aria-pressed={active}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition ${
+              active
+                ? 'bg-[color:var(--color-accent)] text-white'
+                : 'bg-[rgba(54,39,24,0.06)] text-[color:var(--color-text)] hover:bg-[rgba(54,39,24,0.12)]'
+            }`}
+          >
+            {platform}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -83,6 +83,16 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
           ) : null}
           {cinemaMeta ? <p className="text-sm font-medium text-muted-foreground">{cinemaMeta}</p> : null}
           {cinemaVenuesLine ? <p className="text-sm text-muted-foreground">{cinemaVenuesLine}</p> : null}
+          {work?.platforms && work.platforms.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">📺 Dispo sur</span>
+              {work.platforms.map((p) => (
+                <span key={p} className="rounded-full bg-[rgba(54,39,24,0.06)] px-2.5 py-0.5 text-xs font-medium text-[color:var(--color-text)]">
+                  {p}
+                </span>
+              ))}
+            </div>
+          ) : null}
           {director || castNames.length > 0 ? (
             <div className="space-y-0.5 text-sm leading-6">
               {director ? (

--- a/app/tests/card-work.test.tsx
+++ b/app/tests/card-work.test.tsx
@@ -32,6 +32,7 @@ const base: WorkCardDto = {
   currency: null,
   cinemaVenueCount: null,
   cinemaVenues: [],
+  platforms: [],
   officialUrl: null,
   sourceUrl: 'https://www.offi.fr/x',
   venueInfo: null,

--- a/app/tests/features/works-query.test.ts
+++ b/app/tests/features/works-query.test.ts
@@ -77,6 +77,32 @@ describe('listDiscoverWorks', () => {
     )
   })
 
+  it('streaming : ne montre que les films dispo (platforms non vide)', async () => {
+    prisma.work.count.mockResolvedValue(0)
+    prisma.work.findMany.mockResolvedValue([])
+
+    await listDiscoverWorks({ per: 10, section: 'streaming' })
+
+    expect(prisma.work.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ section: 'streaming', platforms: { isEmpty: false } }),
+      }),
+    )
+  })
+
+  it('streaming : applique le filtre plateformes (hasSome)', async () => {
+    prisma.work.count.mockResolvedValue(0)
+    prisma.work.findMany.mockResolvedValue([])
+
+    await listDiscoverWorks({ per: 10, section: 'streaming', platforms: ['Netflix', 'Disney+'] })
+
+    expect(prisma.work.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ platforms: { hasSome: ['Netflix', 'Disney+'] } }),
+      }),
+    )
+  })
+
   it('excludes works whose end date is before today', async () => {
     prisma.work.count.mockResolvedValue(0)
     prisma.work.findMany.mockResolvedValue([])

--- a/app/tests/section.test.ts
+++ b/app/tests/section.test.ts
@@ -7,8 +7,13 @@ import {
 } from '@/features/works/section'
 
 describe('sections', () => {
-  it('inclut les 6 sections', () => {
-    expect(WORK_SECTION_VALUES).toEqual(['theatre', 'cinema', 'exposition', 'concert', 'visite', 'enfants'])
+  it('inclut les 7 sections (dont streaming)', () => {
+    expect(WORK_SECTION_VALUES).toEqual(['theatre', 'cinema', 'streaming', 'exposition', 'concert', 'visite', 'enfants'])
+  })
+
+  it('streaming : libellé et crédit', () => {
+    expect(workSectionLabel('streaming')).toBe('Streaming')
+    expect(workDirectorLabel('streaming')).toBe('De')
   })
 
   it('infère la section depuis l’URL offi', () => {


### PR DESCRIPTION
## Objectif
Nouvel onglet **Streaming** dans Découverte : films dispo en streaming en France, **filtre par plateforme**, et **info plateforme sur la fiche**.

## Source : TMDB (validé)
API officielle TMDB (données FR propulsées par JustWatch). On liste, par plateforme, les films dispo **sans surcoût** (`flatrate|free|ads` → abonnement + chaînes gratuites/ads ; exclut location/achat), on **agrège les plateformes par film**, et on upsert des `Work(section='streaming')`. Pas d'appel détail par film → rapide (catalogue large).

Plateformes ciblées : **Netflix, Prime Video, Disney+, Canal+, Arte, France TV, TF1+, M6+**. Documentaires **inclus d'office** (genre TMDB). Filtre dynamique = plateformes réellement présentes.

## Ce que ça ajoute
- Section `streaming` → onglet + deck à swiper (réutilise tout l'existant).
- `Work.platforms String[]` (+ index GIN) — migration `add_work_platforms`.
- `scripts/ingest-tmdb-streaming.ts` (idempotent : vide `platforms` des films ayant quitté toutes les plateformes → masqués, sans suppression).
- Query : filtre `platforms` (hasSome) + masque les films streaming sans dispo ; `listStreamingPlatforms()` pour les options.
- UI : `StreamingPlatformFilter` (toggles via URL), chips plateformes (carte + modal), CTA « Où regarder » dans le modal.

## ⚠️ À faire avant merge
Nécessite `TMDB_API_KEY` (clé v3) en env. L'ingestion sera lancée une fois la clé fournie ; **je ne merge pas tant que l'onglet serait vide**. Clé aussi à ajouter sur Vercel pour le cron de refresh.

## Tests
vitest 116 ✓ (dont filtre streaming) · tsc ✓ · eslint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
