### PR TITLE
ci: refresh hebdomadaire du catalogue streaming (TMDB)

### DIFF
--- a/.github/workflows/streaming-refresh.yml
+++ b/.github/workflows/streaming-refresh.yml
@@ -1,0 +1,62 @@
+name: Streaming refresh
+
+# Rafraîchit le catalogue « streaming » (films par plateforme) depuis TMDB → Neon,
+# une fois par semaine (lundi 04:00 UTC). L'ingestion est idempotente : elle met à
+# jour les plateformes par film et VIDE `platforms` des films ayant quitté toutes les
+# plateformes (→ masqués côté Découverte, sans suppression : réactions préservées).
+#
+# Pré-requis : secrets de dépôt DATABASE_URL (Neon) et TMDB_API_KEY (clé v3 TMDB).
+
+on:
+  schedule:
+    - cron: '0 4 * * 1' # lundi 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      maxPages:
+        description: 'Pages /discover par plateforme (20 ≈ 400 films/plateforme)'
+        required: false
+        default: '30'
+
+concurrency:
+  group: streaming-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+      # env.ts exige NEXTAUTH_SECRET ; l'ingestion ne l'utilise pas → placeholder.
+      NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'ci-ingestion-placeholder' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          # Node 22 : Prisma 7 (migrate deploy) importe node:sqlite, absent de Node 20.
+          node-version: 22
+          package-manager-cache: false
+      - run: corepack enable
+      - run: corepack prepare pnpm@10.0.0 --activate
+
+      - name: Install app deps (postinstall → prisma generate)
+        working-directory: app
+        run: pnpm install --frozen-lockfile
+
+      # Fail-fast : valide DB + migrations en ~10 s (et applique add_work_platforms si besoin).
+      - name: Preflight — migrations
+        working-directory: app
+        run: pnpm exec prisma migrate deploy --schema prisma/schema.prisma
+
+      - name: Guard — clé TMDB présente
+        run: |
+          if [ -z "${TMDB_API_KEY}" ]; then
+            echo "::error::Secret TMDB_API_KEY manquant (Settings → Secrets → Actions)."
+            exit 1
+          fi
+
+      - name: Ingest TMDB streaming
+        working-directory: app
+        run: pnpm exec tsx scripts/ingest-tmdb-streaming.ts "${{ github.event.inputs.maxPages || '30' }}"

--- a/AGENT.md
+++ b/AGENT.md
@@ -210,7 +210,7 @@ Hard-won, repo-specific facts. Read before touching scraper, ingestion, CI, or t
 
 ## Sections (Work.section)
 
-- Six sections, free-string column (no DB enum): `theatre`, `cinema`, `exposition`, `concert`, `visite`, `enfants`.
+- Seven sections, free-string column (no DB enum): `theatre`, `cinema`, `streaming`, `exposition`, `concert`, `visite`, `enfants`. All are offi-sourced **except `streaming`** (TMDB — see below).
 - **Single source of truth: `app/src/features/works/section.ts`** — `WORK_SECTION_VALUES`, `WORK_SECTION_LABELS` (FR), `inferWorkSectionFromUrl`, `workSectionLabel`, `workDirectorLabel`. Ingestion (`offi-import/schemas`) and the works API import from here; add a section in one place.
 - Offi URL shapes: all sections are venue-based `/{section}/{venue}-{id}/{show}-{id}.html` (theatre, exposition `expositions-musees`, concert `concerts`, visite `visites-conferences`, enfants `enfants`) **except cinema** which is `/cinema/evenement/{slug}-{id}.html` (no venue — a film plays in many cinemas).
 - UI: section badge + `workDirectorLabel` per section; arrondissement shows for all venue-based sections (not cinema); cinema shows nationality·year + "N salles".
@@ -235,6 +235,20 @@ Hard-won, repo-specific facts. Read before touching scraper, ingestion, CI, or t
 
 - `Venue` model (`kind: theatre | cinema`), `Work.venueId` (nullable, `onDelete: SetNull`). Theatre shows link 1:1; cinema is a catalog only (a film has many venues). `app/scripts/backfill-venues.ts` derives theatre venue URLs from show URLs and relinks; cinema venues are harvested from film pages.
 
+## Source links (Work.officialUrl)
+
+- `Venue.website` = venue official site (offi marks it `rel="external"` on the **venue** page; `parsers.extract_official_website` + social/share host filter). `Work.officialUrl` = the **show-specific** external link when offi exposes one **on the show page** (`rel="external"`) — present for expo/concert, **absent for theatre** (offi handles theatre booking in-house).
+- UI priority (`SourceLink`): title → `officialUrl` (dedicated page) when present; venue name → `Venue.website`; else fall back to the offi link. Copy button sits on the primary source.
+- **Theatre deep links are discovered, not built**: there is no common URL scheme across venue sites (`/spectacle/`, `/project/`, slug-at-root…). `scraper/discover.py` (`slugify`/`tokens`/`match_titles`, unit-tested) inspects the venue homepage and matches each title **conservatively** (exact-slug, or ≥2 significant tokens) — a wrong link is worse than none. `app/scripts/backfill-official-url-from-venue.ts` fetches the venue site, matches, and writes `officialUrl` **only if the URL returns 200**. Coverage is partial (only shows listed on the homepage; some sites 403/SSL-fail).
+
+## Streaming (TMDB)
+
+- `section='streaming'` films come from **TMDB** (`watch/providers` is JustWatch-powered, FR). No offi. `Work.platforms String[]` (+ GIN index) holds the subscription platforms; `Work.sourceUrl` = TMDB movie URL (stable upsert key), `officialUrl` = TMDB where-to-watch (`/movie/{id}/watch?locale=FR`).
+- `app/scripts/ingest-tmdb-streaming.ts` (needs `TMDB_API_KEY`, v3 key): resolves provider IDs **by name** from the FR list, then `/discover/movie` per platform with `with_watch_monetization_types=flatrate|free|ads` (= no extra cost; excludes rent/buy), **aggregating platforms per film**. No per-film detail call (fast, large catalogue). Idempotent: after the run, films not seen get `platforms=[]` (→ hidden, not deleted — reactions preserved).
+- Targeted platforms: Netflix, Prime Video, Disney+, Canal+, Arte, TF1+, M6+. **France TV is NOT a TMDB movie provider in FR** (only "France TV Amazon Channel") → absent.
+- Query (`listDiscoverWorks`): streaming filters `platforms: { isEmpty: false }` (hide departed) + optional `platforms hasSome` filter; `listStreamingPlatforms()` powers the filter UI (`StreamingPlatformFilter`, state in the URL). Card/modal show platform chips; modal CTA is "Où regarder".
+- TMDB poster URLs (`image.tmdb.org`) pass through `image-loader.ts` unchanged (only offi URLs are rewritten).
+
 ## Mobile / touch UX
 
 - Swipe (`SwipeDeck`): track horizontal drag via **absolute `clientX - startX`**, never `event.movementX` (unreliable/0 on touch). Capture the pointer on the card; card has `touch-action: none`.
@@ -253,7 +267,8 @@ Hard-won, repo-specific facts. Read before touching scraper, ingestion, CI, or t
   - **pnpm 10** via `corepack prepare pnpm@10.0.0 --activate` (project pins `packageManager: pnpm@10`; the pipeline runs `pnpm --dir app` from repo root where corepack would otherwise pick pnpm 11 and refuse).
   - **Preflight `prisma migrate deploy` BEFORE the scrape** (fail-fast: env errors surface in ~10s, not after a ~40min scrape). Pipeline runs with `OFFI_SKIP_DB_DEPLOY=1`.
   - **Cache `data/offi.jsonl`** with `actions/cache/restore` + `actions/cache/save` (`if: always()`) so a failed run's scrape is preserved → incremental retries.
-- The pipeline (`scripts/offi-pipeline.sh`) and CLI default to all 6 sections. A full 6-section scrape is long; the job `timeout-minutes` is 90.
+- The pipeline (`scripts/offi-pipeline.sh`) and CLI default to all 6 offi sections. A full 6-section scrape is long; the job `timeout-minutes` is 90.
+- **`streaming-refresh.yml`** (weekly, Mon 04:00 UTC + `workflow_dispatch`) runs `ingest-tmdb-streaming.ts` → Neon. Required repo secrets: **`DATABASE_URL`** + **`TMDB_API_KEY`** (the app itself never calls TMDB at runtime — it only reads the DB, so prod/Vercel does NOT need the key).
 
 ## Backfill scripts
 


### PR DESCRIPTION
## Objectif
Refresh **hebdomadaire** du catalogue streaming (films par plateforme) depuis TMDB → Neon. Le catalogue bouge lentement → 1×/semaine suffit.

## Détail
- `.github/workflows/streaming-refresh.yml` : lundi 04:00 UTC (+ `workflow_dispatch` avec `maxPages`). Node 22 / pnpm 10, preflight `prisma migrate deploy`, guard si la clé manque, puis `ingest-tmdb-streaming.ts`.
- Idempotent : met à jour les plateformes par film et **vide `platforms`** des films ayant quitté toutes les plateformes (→ masqués, sans suppression).
- `AGENT.md` enrichi : sous-systèmes **streaming (TMDB)** et **source links** (`officialUrl` / `discover.py`) + entrée runbook du cron streaming.

## ⚠️ Secret requis
Le cron échouera (avec message clair) tant que **`TMDB_API_KEY`** n'est pas ajouté en secret de dépôt (Settings → Secrets and variables → Actions). `DATABASE_URL` existe déjà. L'app en prod n'a PAS besoin de la clé (elle ne lit que la base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
