### PR TITLE
fix(streaming): autoriser image.tmdb.org dans la CSP img-src

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -12,7 +12,7 @@ const contentSecurityPolicy = [
   "default-src 'self'",
   `script-src ${scriptSrc}`,
   "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' https://*.offi.fr data: blob:",
+  "img-src 'self' https://*.offi.fr https://image.tmdb.org data: blob:",
   "font-src 'self'",
   "connect-src 'self'",
   "base-uri 'self'",
@@ -43,6 +43,7 @@ const nextConfig = {
       { protocol: 'https', hostname: 'files.offi.fr' },
       { protocol: 'https', hostname: 'images.offi.fr' },
       { protocol: 'https', hostname: 'www.offi.fr' },
+      { protocol: 'https', hostname: 'image.tmdb.org' }, // affiches streaming (TMDB)
     ],
   },
   env: {


### PR DESCRIPTION
## Problème
Les affiches des films **streaming** ne s'affichaient pas : la CSP `img-src` n'autorisait que `*.offi.fr`, donc `image.tmdb.org` (affiches TMDB) était bloqué par le navigateur.

## Fix
- `img-src` : ajout de `https://image.tmdb.org`.
- `images.remotePatterns` : ajout de `image.tmdb.org` (cohérence/robustesse).

Une ligne, sans risque. lint + tsc OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)