### PR TITLE
fix(discover): repli de la description à chaque nouvelle fiche

### DIFF
--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -161,7 +161,10 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
           </div>
         ) : null}
 
-        {description ? <ExpandableDescription text={description} /> : null}
+        {/* key={work.id} : le deck réutilise l'instance de carte d'un swipe à l'autre ;
+            on remonte la description à chaque fiche pour repartir replié (« Voir plus »)
+            et ne pas conserver l'état déplié de la fiche précédente. */}
+        {description ? <ExpandableDescription key={work.id} text={description} /> : null}
 
         {/* Fallback Offi : seulement quand aucune source (lien dédié de la fiche ni site
             du lieu) n'est disponible — ex. cinéma, ou lieu non encore relié. */}

--- a/app/tests/card-work.test.tsx
+++ b/app/tests/card-work.test.tsx
@@ -68,6 +68,17 @@ describe('CardWork', () => {
     expect(screen.getByRole('button', { name: /voir moins/i })).toBeInTheDocument()
   })
 
+  it('réinitialise « Voir plus » (replié) quand la fiche change', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<CardWork work={base} />)
+    await user.click(screen.getByRole('button', { name: /voir plus/i }))
+    expect(screen.getByRole('button', { name: /voir moins/i })).toBeInTheDocument()
+    // Nouvelle fiche (id différent) : le deck réutilise l'instance → doit repartir replié.
+    rerender(<CardWork work={{ ...base, id: 'w2', title: 'Autre', description: 'B'.repeat(200) }} />)
+    expect(screen.getByRole('button', { name: /voir plus/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /voir moins/i })).not.toBeInTheDocument()
+  })
+
   it('n’affiche pas de fait quand la donnée est absente (pas de placeholder)', () => {
     render(<CardWork work={{ ...base, durationMin: null, priceMin: null, priceMax: null, category: null }} />)
     expect(screen.queryByText(/Tarifs non communiqués/)).not.toBeInTheDocument()


### PR DESCRIPTION
## Problème
Sur Découverte, le deck réutilise l'instance de carte d'un swipe à l'autre (pour le `ref`/swipe). L'état « déplié » de la description (Voir plus) **persistait** donc sur la fiche suivante.

## Fix
`<ExpandableDescription key={work.id} …>` dans `CardWork` : la description se **remonte à chaque nouvelle fiche** → repart **repliée** (« Voir plus » par défaut), sans mémoriser la fiche précédente. Correction chirurgicale (n'affecte ni le swipe ni l'image).

Test ajouté (déplie puis change de fiche → repart replié). vitest 13 ✓ · tsc ✓ · eslint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)