### PR TITLE
feat: note (TMDB) sur les fiches films (ciné + streaming)

### DIFF
--- a/app/prisma/migrations/20260609200000_add_work_rating/migration.sql
+++ b/app/prisma/migrations/20260609200000_add_work_rating/migration.sql
@@ -1,0 +1,3 @@
+-- Note publique du film (TMDB /10) + nombre de votes. Films uniquement (ciné + streaming).
+ALTER TABLE "Work" ADD COLUMN "rating" DOUBLE PRECISION;
+ALTER TABLE "Work" ADD COLUMN "ratingCount" INTEGER;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -93,6 +93,8 @@ model Work {
   cinemaVenueCount Int?    // nb de salles où le film est programmé (cinéma)
   cinemaVenues String[]    // échantillon de noms de salles (cinéma)
   platforms String[]       // plateformes de streaming (abonnement) où le film est dispo : "Netflix", "Disney+"…
+  rating      Float?       // note publique du film (TMDB /10) — films (ciné + streaming)
+  ratingCount Int?         // nombre de votes derrière la note
   officialUrl String?      // lien externe dédié de la fiche (rel="external") : site de l'expo, page du concert…
   sourceUrl String    @unique
 

--- a/app/scripts/backfill-tmdb-rating.ts
+++ b/app/scripts/backfill-tmdb-rating.ts
@@ -1,0 +1,98 @@
+// Backfill Work.rating / ratingCount pour les films CINÉMA (offi) via TMDB.
+// On recherche le film sur TMDB par titre (+ année de production si connue), on
+// valide le match de façon conservatrice (slug exact ou ≥60 % des tokens du titre),
+// puis on stocke la note publique (vote_average) + le nombre de votes.
+// Le streaming récupère sa note directement à l'ingestion → ce backfill cible le ciné.
+//
+// Re-runnable : ne traite que les films sans rating. Pré-requis : TMDB_API_KEY.
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/backfill-tmdb-rating.ts [section] [limit]
+import { prisma } from '@/server/db'
+
+const API = 'https://api.themoviedb.org/3'
+const KEY = process.env.TMDB_API_KEY
+const section = process.argv[2] ?? 'cinema'
+const limit = Number(process.argv[3] ?? 5000)
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+const slugify = (s: string) =>
+  (s || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+const tokens = (s: string) => new Set(slugify(s).split('-').filter((t) => t.length >= 3))
+
+// Match conservateur entre le titre offi et un résultat TMDB.
+function isMatch(offiTitle: string, candidate: { title?: string; original_title?: string }): boolean {
+  const tt = tokens(offiTitle)
+  if (tt.size === 0) return false
+  const offiSlug = slugify(offiTitle)
+  for (const name of [candidate.title, candidate.original_title]) {
+    if (!name) continue
+    const cslug = slugify(name)
+    if (offiSlug && offiSlug === cslug) return true
+    const ct = tokens(name)
+    const inter = [...tt].filter((t) => ct.has(t)).length
+    if (inter >= 1 && inter / tt.size >= 0.6) return true
+  }
+  return false
+}
+
+async function searchRating(title: string, year: number | null): Promise<{ rating: number; ratingCount: number } | null> {
+  const params = new URLSearchParams({ api_key: KEY!, language: 'fr-FR', query: title, include_adult: 'false' })
+  if (year) params.set('primary_release_year', String(year))
+  const res = await fetch(`${API}/search/movie?${params}`, { signal: AbortSignal.timeout(15_000) })
+  if (!res.ok) return null
+  const data = await res.json()
+  const results = (data.results ?? []) as Array<{
+    title?: string
+    original_title?: string
+    vote_average?: number
+    vote_count?: number
+  }>
+  // On parcourt les premiers résultats (les plus pertinents) et on prend le 1er qui matche.
+  for (const r of results.slice(0, 5)) {
+    if (isMatch(title, r) && typeof r.vote_average === 'number' && r.vote_average > 0) {
+      return { rating: r.vote_average, ratingCount: r.vote_count ?? 0 }
+    }
+  }
+  return null
+}
+
+async function main() {
+  if (!KEY) throw new Error('TMDB_API_KEY manquant (env).')
+
+  const films = await prisma.work.findMany({
+    where: { section, rating: null },
+    select: { id: true, title: true, year: true },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  let updated = 0
+  let missing = 0
+  for (const f of films) {
+    try {
+      const hit = await searchRating(f.title, f.year)
+      if (hit) {
+        await prisma.work.update({ where: { id: f.id }, data: { rating: hit.rating, ratingCount: hit.ratingCount } })
+        updated += 1
+      } else {
+        missing += 1
+      }
+      await sleep(120) // throttle poli (TMDB ~50 req/s)
+    } catch {
+      missing += 1
+    }
+  }
+
+  console.log(JSON.stringify({ section, scanned: films.length, updated, missing }))
+}
+
+main()
+  .catch((error) => {
+    console.error('[backfill-tmdb-rating]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/app/scripts/ingest-tmdb-streaming.ts
+++ b/app/scripts/ingest-tmdb-streaming.ts
@@ -37,7 +37,16 @@ const TARGETS: { canonical: string; aliases: string[] }[] = [
   { canonical: 'M6+', aliases: ['m6+', '6play', 'm6 plus'] },
 ]
 
-type Movie = { id: number; title: string; overview: string; poster_path: string | null; release_date: string; genre_ids: number[] }
+type Movie = {
+  id: number
+  title: string
+  overview: string
+  poster_path: string | null
+  release_date: string
+  genre_ids: number[]
+  vote_average?: number
+  vote_count?: number
+}
 
 async function tmdb(path: string, params: Record<string, string> = {}): Promise<any> {
   const qs = new URLSearchParams({ api_key: KEY!, language: LANG, ...params })
@@ -115,6 +124,8 @@ async function main() {
           imageUrl: movie.poster_path ? `${IMG}${movie.poster_path}` : null,
           year: year && year >= 1880 && year <= 2100 ? year : null,
           platforms: [...platforms].sort(),
+          rating: typeof movie.vote_average === 'number' && movie.vote_average > 0 ? movie.vote_average : null,
+          ratingCount: typeof movie.vote_count === 'number' ? movie.vote_count : null,
           officialUrl: `https://www.themoviedb.org/movie/${movie.id}/watch?locale=${REGION}`,
         }
         const sourceUrl = `https://www.themoviedb.org/movie/${movie.id}`

--- a/app/src/features/works/dto.ts
+++ b/app/src/features/works/dto.ts
@@ -25,6 +25,8 @@ export const workCardSelect = {
   cinemaVenueCount: true,
   cinemaVenues: true,
   platforms: true,
+  rating: true,
+  ratingCount: true,
   officialUrl: true,
   sourceUrl: true,
   venue_ref: {
@@ -58,6 +60,8 @@ export type WorkCardDto = {
   cinemaVenueCount: number | null
   cinemaVenues: string[]
   platforms: string[]
+  rating: number | null
+  ratingCount: number | null
   officialUrl: string | null
   sourceUrl: string | null
   venueInfo: {
@@ -95,6 +99,8 @@ export function mapWorkToCardDto(work: WorkCardRecord): WorkCardDto {
     cinemaVenueCount: work.cinemaVenueCount,
     cinemaVenues: work.cinemaVenues,
     platforms: work.platforms,
+    rating: work.rating,
+    ratingCount: work.ratingCount,
     officialUrl: work.officialUrl,
     sourceUrl: work.sourceUrl,
     venueInfo: work.venue_ref

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -18,7 +18,12 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
   const description = work.description?.trim()
   const sectionLabel = workSectionLabel(work.section)
   const directorLabel = workDirectorLabel(work.section)
-  const hasFacts = Boolean(durationLabel) || Boolean(priceLabel) || Boolean(availability)
+  // Note publique (films) : affichée si ≥ 20 votes (sinon trop bruitée).
+  const ratingLabel =
+    work.rating != null && work.rating > 0 && (work.ratingCount ?? 0) >= 20
+      ? work.rating.toFixed(1).replace('.', ',')
+      : null
+  const hasFacts = Boolean(durationLabel) || Boolean(priceLabel) || Boolean(availability) || Boolean(ratingLabel)
   // Ligne d'eyebrow : lieu + arrondissement (toutes sections « lieu » sauf le cinéma,
   // qui affiche plutôt nationalité·année).
   const venueLine = [work.venue, work.section !== 'cinema' ? work.arrondissement : null]
@@ -143,6 +148,11 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
 
         {hasFacts ? (
           <div className="flex flex-wrap items-center gap-2">
+            {ratingLabel ? (
+              <span className="rounded-full bg-[rgba(212,160,23,0.16)] px-3 py-1 text-xs font-semibold text-[#7a5c00]">
+                ⭐ {ratingLabel}
+              </span>
+            ) : null}
             {durationLabel ? (
               <span className="rounded-full bg-[rgba(54,39,24,0.06)] px-3 py-1 text-xs font-medium text-[color:var(--color-text)]">
                 ⏱️ {durationLabel}

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -20,6 +20,10 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
   const dateLabel = work ? formatDateRange(work.startDate, work.endDate) : null
   const priceLabel = work ? formatPriceRange(work.priceMin, work.priceMax) : null
   const durationLabel = work ? formatDuration(work.durationMin) : null
+  const ratingLabel =
+    work?.rating != null && work.rating > 0 && (work.ratingCount ?? 0) >= 20
+      ? work.rating.toFixed(1).replace('.', ',')
+      : null
   const description = work?.description?.trim()
   const director = work?.director?.trim()
   const castNames = work?.cast?.slice(0, 5) ?? []
@@ -113,6 +117,7 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
         </div>
 
         <div className="grid gap-2 text-sm text-[color:var(--color-text)]">
+          {ratingLabel ? <SummaryRow label="Note" value={`⭐ ${ratingLabel}/10`} /> : null}
           {dateLabel ? <SummaryRow label="Dates" value={dateLabel} /> : null}
           {priceLabel ? <SummaryRow label="Budget" value={priceLabel} /> : null}
           {durationLabel ? <SummaryRow label="Durée" value={durationLabel} /> : null}

--- a/app/tests/card-work.test.tsx
+++ b/app/tests/card-work.test.tsx
@@ -33,6 +33,8 @@ const base: WorkCardDto = {
   cinemaVenueCount: null,
   cinemaVenues: [],
   platforms: [],
+  rating: null,
+  ratingCount: null,
   officialUrl: null,
   sourceUrl: 'https://www.offi.fr/x',
   venueInfo: null,
@@ -88,6 +90,14 @@ describe('CardWork', () => {
   it('cinéma : affiche la nationalité et l’année', () => {
     render(<CardWork work={{ ...base, venue: null }} />)
     expect(screen.getByText('États-Unis · 2008')).toBeInTheDocument()
+  })
+
+  it('affiche la note (⭐) quand elle a assez de votes, pas en dessous du seuil', () => {
+    const { rerender } = render(<CardWork work={{ ...base, rating: 8.44, ratingCount: 320 }} />)
+    expect(screen.getByText(/⭐ 8,4/)).toBeInTheDocument()
+    // sous le seuil de votes → pas de note (trop bruitée)
+    rerender(<CardWork work={{ ...base, id: 'w-low', rating: 9.5, ratingCount: 3 }} />)
+    expect(screen.queryByText(/⭐/)).not.toBeInTheDocument()
   })
 
   it('affiche un badge « Billets dispo » quand availability=InStock', () => {


### PR DESCRIPTION
## Objectif
Afficher la **note publique /10** (TMDB) sur les fiches **films** (cinéma + streaming).

## Décisions respectées
- **Aucune réduction** du catalogue streaming : on garde **tous les films** (vérifié : 3 277 = 100% films, 0 série — l'import passe uniquement par `/discover/movie`).
- Films uniquement, pas de séries.

## Détail
- `Work.rating` (Float) + `Work.ratingCount` (Int) — migration `add_work_rating`.
- **Streaming** : l'ingestion TMDB capte `vote_average`/`vote_count` à la volée (aucun appel supplémentaire). → 3 084/3 277 notés.
- **Cinéma** : `backfill-tmdb-rating.ts` recherche le film sur TMDB par titre + année, **match conservateur** (slug exact ou ≥60% des tokens), stocke la note.
- **UI** : chip `⭐ 8,4` dans `CardWork`, ligne « Note » dans le modal. Affichée seulement si **≥ 20 votes** (sinon trop bruitée).

## Tests
vitest 14 (card-work, dont seuil de votes) ✓ · tsc ✓ · eslint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)