### PR TITLE
feat(ui): refonte « cinéma sombre » (palette dark + corail + icônes)

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -1,33 +1,36 @@
 @import "tailwindcss";
 
 :root {
+  color-scheme: dark;
   --font-manrope: "Manrope", ui-sans-serif, system-ui, sans-serif;
-  --color-page: #f3ede3;
-  --color-page-top: #faf6ef;
-  --color-surface: rgba(255, 251, 246, 0.9);
-  --color-surface-strong: #fffdf9;
-  --color-surface-muted: #efe7da;
-  --color-border: rgba(83, 63, 43, 0.14);
-  --color-border-strong: rgba(83, 63, 43, 0.24);
-  --color-text: #201710;
-  --color-text-muted: #6f5b49;
-  --color-accent: #0f5d5e;
-  --color-accent-strong: #0a494a;
-  --color-accent-soft: #e6f4f2;
-  --color-danger: #a04a41;
-  --color-danger-soft: #f9ece9;
-  --color-success: #23644b;
-  --color-success-soft: #e8f4ed;
-  --shadow-sm: 0 2px 8px rgba(54, 39, 24, 0.06);
-  --shadow-lg: 0 8px 24px rgba(54, 39, 24, 0.09);
+  /* Cinéma sombre : fond quasi-noir, texte clair chaud, accent corail. */
+  --color-page: #0c0d11;
+  --color-page-top: #14161c;
+  --color-surface: rgba(255, 255, 255, 0.045);
+  --color-surface-strong: #1a1d25;
+  --color-surface-muted: #23262f;
+  --color-border: rgba(255, 255, 255, 0.10);
+  --color-border-strong: rgba(255, 255, 255, 0.20);
+  --color-text: #f3f0ea;
+  --color-text-muted: #9aa0ad;
+  --color-accent: #f25c54;
+  --color-accent-strong: #e0453d;
+  --color-accent-soft: rgba(242, 92, 84, 0.15);
+  --color-danger: #ff6b6b;
+  --color-danger-soft: rgba(255, 107, 107, 0.14);
+  --color-success: #4cd0a0;
+  --color-success-soft: rgba(76, 208, 160, 0.14);
+  --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 18px 44px rgba(0, 0, 0, 0.55);
   /* Échelle de rayons (du plus petit au plus grand). Les composants doivent
-     piocher dans cette échelle plutôt que de coder des valeurs en dur. */
-  --radius-control: 0.7rem;
-  --radius-panel: 1rem;
-  --radius-md: 1.25rem;
-  --radius-lg: 1.5rem;
-  --radius-xl: 1.85rem;
-  --radius-2xl: 2rem;
+     piocher dans cette échelle plutôt que de coder des valeurs en dur.
+     Resserrée pour un rendu plus net (moins « bubble »). */
+  --radius-control: 0.55rem;
+  --radius-panel: 0.85rem;
+  --radius-md: 1rem;
+  --radius-lg: 1.15rem;
+  --radius-xl: 1.35rem;
+  --radius-2xl: 1.5rem;
 }
 
 * {
@@ -71,7 +74,7 @@ a {
 }
 
 ::selection {
-  background: rgba(15, 93, 94, 0.16);
+  background: rgba(242, 92, 84, 0.16);
 }
 
 .text-muted-foreground {
@@ -95,7 +98,7 @@ a {
   top: 0;
   z-index: 40;
   border-bottom: 1px solid var(--color-border);
-  background: rgba(250, 246, 239, 0.82);
+  background: rgba(12, 13, 17, 0.72);
   backdrop-filter: blur(20px);
 }
 
@@ -134,13 +137,13 @@ a {
   gap: 2rem;
   padding: 2rem;
   background:
-    linear-gradient(180deg, rgba(15, 93, 94, 0.08), transparent 45%),
+    linear-gradient(180deg, rgba(242, 92, 84, 0.08), transparent 45%),
     var(--color-surface);
 }
 
 .auth-main {
   padding: 1.25rem;
-  background: rgba(255, 253, 249, 0.95);
+  background: #1a1d25;
 }
 
 .auth-title {
@@ -167,9 +170,9 @@ a {
   display: grid;
   gap: 0.35rem;
   padding: 1rem 1.1rem;
-  border: 1px solid rgba(15, 93, 94, 0.12);
+  border: 1px solid rgba(242, 92, 84, 0.12);
   border-radius: var(--radius-control);
-  background: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .auth-highlight-label {
@@ -248,7 +251,7 @@ a {
   padding: 0.7rem 0.95rem;
   border: 1px solid var(--color-border);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.06);
   font-size: 0.82rem;
   font-weight: 600;
   color: var(--color-text-muted);
@@ -264,12 +267,12 @@ a {
 }
 
 .surface-card--muted {
-  background: rgba(255, 253, 249, 0.7);
+  background: #1a1d25;
 }
 
 .surface-card--accent {
-  border-color: rgba(15, 93, 94, 0.14);
-  background: linear-gradient(180deg, rgba(15, 93, 94, 0.06), rgba(255, 253, 249, 0.96));
+  border-color: rgba(242, 92, 84, 0.14);
+  background: linear-gradient(180deg, rgba(242, 92, 84, 0.06), #1a1d25);
 }
 
 .btn {
@@ -281,7 +284,7 @@ a {
   padding: 0.7rem 1rem;
   border: 1px solid var(--color-border);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.06);
   font-size: 0.92rem;
   font-weight: 600;
   color: var(--color-text);
@@ -290,7 +293,7 @@ a {
 
 .btn:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(54, 39, 24, 0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
 
 .btn:disabled {
@@ -302,7 +305,7 @@ a {
   border-color: transparent;
   background: var(--color-accent);
   color: #fff;
-  box-shadow: 0 3px 10px rgba(15, 93, 94, 0.16);
+  box-shadow: 0 3px 10px rgba(242, 92, 84, 0.16);
 }
 
 .btn-primary:hover:not(:disabled) {
@@ -310,7 +313,7 @@ a {
 }
 
 .btn-secondary {
-  background: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.10);
 }
 
 .btn-danger {
@@ -331,7 +334,7 @@ a {
   width: 100%;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-control);
-  background: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.10);
   padding: 0.92rem 1rem;
   font-size: 0.95rem;
   color: var(--color-text);
@@ -340,18 +343,18 @@ a {
 
 .input::placeholder,
 .textarea::placeholder {
-  color: color-mix(in srgb, var(--color-text-muted) 78%, white);
+  color: color-mix(in srgb, var(--color-text-muted) 68%, black);
 }
 
 .input:focus,
 .textarea:focus {
   outline: none;
-  border-color: rgba(15, 93, 94, 0.36);
-  box-shadow: 0 0 0 4px rgba(15, 93, 94, 0.12);
+  border-color: rgba(242, 92, 84, 0.36);
+  box-shadow: 0 0 0 4px rgba(242, 92, 84, 0.12);
 }
 
 .input[readonly] {
-  background: rgba(244, 238, 230, 0.92);
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .label {
@@ -378,7 +381,7 @@ a {
   /* Rectangle arrondi (pas un stadium 999px) : reste propre quand les onglets
      passent sur deux lignes en écran étroit (mobile). */
   border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.06);
   box-shadow: var(--shadow-sm);
 }
 
@@ -408,7 +411,7 @@ a {
   min-height: 2.4rem;
   white-space: nowrap;
   border: 1px solid var(--color-border);
-  background: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.06);
 }
 .segmented-control--scroll .segmented-control__item--active {
   border-color: var(--color-accent);
@@ -437,7 +440,7 @@ a {
 .segmented-control__item--active {
   background: var(--color-surface-strong);
   color: var(--color-text);
-  box-shadow: 0 2px 6px rgba(54, 39, 24, 0.08);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
 .segmented-control__item--full {
@@ -454,7 +457,7 @@ a {
   height: 1.5rem;
   padding: 0 0.35rem;
   border-radius: 999px;
-  background: rgba(15, 93, 94, 0.12);
+  background: rgba(242, 92, 84, 0.12);
   font-size: 0.74rem;
   color: var(--color-accent);
 }
@@ -473,7 +476,7 @@ a {
 }
 
 .status-banner--info {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.06);
   color: var(--color-text);
 }
 
@@ -513,7 +516,7 @@ a {
 .skeleton {
   position: relative;
   overflow: hidden;
-  background: rgba(227, 218, 204, 0.8);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .skeleton::after {
@@ -521,7 +524,7 @@ a {
   position: absolute;
   inset: 0;
   transform: translateX(-100%);
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.52), transparent);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.14), transparent);
   animation: shimmer 1.3s linear infinite;
 }
 

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -3,12 +3,12 @@
 :root {
   color-scheme: dark;
   --font-manrope: "Manrope", ui-sans-serif, system-ui, sans-serif;
-  /* Cinéma sombre : charbon doux (pas noir profond), texte clair chaud, accent corail. */
-  --color-page: #181a21;
-  --color-page-top: #21242d;
-  --color-surface: rgba(255, 255, 255, 0.05);
-  --color-surface-strong: #262a34;
-  --color-surface-muted: #30343f;
+  /* Cinéma sombre : gris ardoise (franchement éclairci), texte clair chaud, accent corail. */
+  --color-page: #2a2f38;
+  --color-page-top: #333944;
+  --color-surface: rgba(255, 255, 255, 0.06);
+  --color-surface-strong: #373d48;
+  --color-surface-muted: #424955;
   --color-border: rgba(255, 255, 255, 0.10);
   --color-border-strong: rgba(255, 255, 255, 0.20);
   --color-text: #f3f0ea;

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -3,12 +3,12 @@
 :root {
   color-scheme: dark;
   --font-manrope: "Manrope", ui-sans-serif, system-ui, sans-serif;
-  /* Cinéma sombre : fond quasi-noir, texte clair chaud, accent corail. */
-  --color-page: #0c0d11;
-  --color-page-top: #14161c;
-  --color-surface: rgba(255, 255, 255, 0.045);
-  --color-surface-strong: #1a1d25;
-  --color-surface-muted: #23262f;
+  /* Cinéma sombre : charbon doux (pas noir profond), texte clair chaud, accent corail. */
+  --color-page: #181a21;
+  --color-page-top: #21242d;
+  --color-surface: rgba(255, 255, 255, 0.05);
+  --color-surface-strong: #262a34;
+  --color-surface-muted: #30343f;
   --color-border: rgba(255, 255, 255, 0.10);
   --color-border-strong: rgba(255, 255, 255, 0.20);
   --color-text: #f3f0ea;

--- a/app/src/features/auth/ui/NavBar.tsx
+++ b/app/src/features/auth/ui/NavBar.tsx
@@ -17,8 +17,8 @@ function NavLink({ href, children }: { href: string; children: React.ReactNode }
       className={cn(
         'inline-flex items-center rounded-full border border-transparent px-4 py-2 text-sm font-semibold tracking-[-0.01em] transition',
         active
-          ? 'border-[color:var(--color-border-strong)] bg-[color:var(--color-surface-strong)] text-[color:var(--color-text)] shadow-[0_12px_30px_rgba(42,30,18,0.08)]'
-          : 'text-[color:var(--color-text-muted)] hover:border-[color:var(--color-border)] hover:bg-white/70 hover:text-[color:var(--color-text)]',
+          ? 'border-[color:var(--color-border-strong)] bg-[color:var(--color-surface-strong)] text-[color:var(--color-text)] shadow-[0_12px_30px_rgba(0,0,0,0.35)]'
+          : 'text-[color:var(--color-text-muted)] hover:border-[color:var(--color-border)] hover:bg-white/5 hover:text-[color:var(--color-text)]',
       )}
       aria-current={active ? 'page' : undefined}
     >
@@ -36,7 +36,7 @@ export default function NavBar() {
     <nav className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 py-4 sm:px-6 lg:flex-row lg:items-center">
       <div className="flex items-center gap-3">
         <Link href="/discover" className="flex items-center gap-3">
-          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[color:var(--color-accent)] text-sm font-bold text-white shadow-[0_14px_30px_rgba(15,93,94,0.25)]">
+          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[color:var(--color-accent)] text-sm font-bold text-white shadow-[0_14px_30px_rgba(242,92,84,0.30)]">
             O
           </span>
           <div>
@@ -51,7 +51,7 @@ export default function NavBar() {
           </span>
         ) : session ? (
           <div className="ml-auto flex items-center gap-2 lg:hidden">
-            <span className="rounded-full border border-[color:var(--color-border)] bg-white/70 px-3 py-1 text-xs text-[color:var(--color-text-muted)]">
+            <span className="rounded-full border border-[color:var(--color-border)] bg-white/5 px-3 py-1 text-xs text-[color:var(--color-text-muted)]">
               {userName}
             </span>
             <LogoutButton />
@@ -85,7 +85,7 @@ export default function NavBar() {
               Chargement
             </span>
           ) : session ? (
-            <div className="flex items-center gap-3 rounded-full border border-[color:var(--color-border)] bg-white/80 px-3 py-2">
+            <div className="flex items-center gap-3 rounded-full border border-[color:var(--color-border)] bg-white/5 px-3 py-2">
               <span className="text-xs font-medium text-[color:var(--color-text-muted)]">Connecté en tant que {userName}</span>
               <LogoutButton />
             </div>

--- a/app/src/features/friendships/ui/FriendsClient.tsx
+++ b/app/src/features/friendships/ui/FriendsClient.tsx
@@ -290,10 +290,10 @@ export default function FriendsClient({ initialFriends, initialRequests, inviteT
                   return (
                     <li
                       key={request.id}
-                      className="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-[color:var(--color-border)] bg-white/72 p-4 sm:flex-row sm:items-center sm:justify-between"
+                      className="flex flex-col gap-3 rounded-[var(--radius-lg)] border border-[color:var(--color-border)] bg-white/5 p-4 sm:flex-row sm:items-center sm:justify-between"
                     >
                       <div className="flex items-center gap-3">
-                        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[rgba(15,93,94,0.12)] text-sm font-semibold text-[color:var(--color-accent)]">
+                        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[rgba(242,92,84,0.16)] text-sm font-semibold text-[color:var(--color-accent)]">
                           {initialsFromEmail(request.email)}
                         </div>
                         <div className="text-sm font-semibold tracking-[-0.02em]">{request.email}</div>
@@ -329,7 +329,7 @@ export default function FriendsClient({ initialFriends, initialRequests, inviteT
           </div>
 
           {friends.length === 0 ? (
-            <div className="empty-state rounded-[var(--radius-lg)] border border-dashed border-[color:var(--color-border)] bg-white/45">
+            <div className="empty-state rounded-[var(--radius-lg)] border border-dashed border-[color:var(--color-border)] bg-white/5">
               <strong>Aucun ami pour le moment.</strong>
               <p className="text-sm leading-7 text-muted-foreground">Commence par partager ton lien ou par inviter un email.</p>
             </div>
@@ -343,11 +343,11 @@ export default function FriendsClient({ initialFriends, initialRequests, inviteT
                 return (
                   <li
                     key={friend.id}
-                    className="rounded-[var(--radius-lg)] border border-[color:var(--color-border)] bg-white/72 p-4 shadow-[0_8px_24px_rgba(54,39,24,0.06)]"
+                    className="rounded-[var(--radius-lg)] border border-[color:var(--color-border)] bg-white/5 p-4 shadow-[0_8px_24px_rgba(255,255,255,0.07)]"
                   >
                     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                       <div className="flex items-center gap-3">
-                        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[rgba(15,93,94,0.12)] text-sm font-semibold text-[color:var(--color-accent)]">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[rgba(242,92,84,0.16)] text-sm font-semibold text-[color:var(--color-accent)]">
                           {initialsFromEmail(friend.email)}
                         </div>
                         <div className="min-w-0 truncate text-sm font-semibold tracking-[-0.02em]">{friend.email}</div>

--- a/app/src/features/reactions/ui/CompactLikeCard.tsx
+++ b/app/src/features/reactions/ui/CompactLikeCard.tsx
@@ -5,6 +5,7 @@ import type { WorkCardDto } from '@/features/works/dto'
 import { workSectionLabel } from '@/features/works/section'
 import WorkImage from '@/features/works/ui/WorkImage'
 import { formatAvailability, formatEndsIn, formatPriceRange } from '@/features/works/ui/work-formatters'
+import { IconUsers } from '@/shared/ui/icons'
 
 function initials(email: string) {
   return (email.split('@')[0] ?? email).slice(0, 2).toUpperCase()
@@ -67,7 +68,7 @@ export default function CompactLikeCard({ work, fallbackTitle, friends, onOpen }
               className={`rounded-full px-2 py-0.5 text-[0.62rem] font-semibold ${
                 ends.urgent
                   ? 'bg-[color:var(--color-danger-soft)] text-[color:var(--color-danger)]'
-                  : 'bg-[rgba(54,39,24,0.06)] text-[color:var(--color-text)]'
+                  : 'bg-[rgba(255,255,255,0.07)] text-[color:var(--color-text)]'
               }`}
             >
               ⏳ {ends.label}
@@ -85,8 +86,8 @@ export default function CompactLikeCard({ work, fallbackTitle, friends, onOpen }
             </span>
           ) : null}
           {friends.length > 0 ? (
-            <span className="inline-flex items-center gap-1 rounded-full bg-[rgba(15,93,94,0.10)] px-2 py-0.5 text-[0.62rem] font-semibold text-[color:var(--color-accent)]">
-              <span aria-hidden>👥</span>
+            <span className="inline-flex items-center gap-1 rounded-full bg-[rgba(242,92,84,0.16)] px-2 py-0.5 text-[0.62rem] font-semibold text-[color:var(--color-accent)]">
+              <IconUsers size={11} />
               {friends.length === 1 ? initials(friends[0].email) : `${friends.length} amis`}
             </span>
           ) : null}

--- a/app/src/features/reactions/ui/LikeDetailModal.tsx
+++ b/app/src/features/reactions/ui/LikeDetailModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 import type { FriendSummaryDto } from '@/features/friendships/dto'
 import type { WorkCardDto } from '@/features/works/dto'
 import WorkSummaryCard from '@/features/works/ui/WorkSummaryCard'
+import { IconAccess, IconMetro, IconPhone, IconPin, IconUsers } from '@/shared/ui/icons'
 import { formatAvailability } from '@/features/works/ui/work-formatters'
 
 export type LikeBucket = 'like' | 'seen'
@@ -88,16 +89,16 @@ export default function LikeDetailModal({ work, fallbackTitle, friends, bucket, 
               {/* Infos pratiques (lieu relié) */}
               {venueMetro || venueAccess || venuePhone ? (
                 <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[color:var(--color-text-muted)]">
-                  {venueMetro ? <span>🚇 {venueMetro}</span> : null}
-                  {venueAccess ? <span>♿ {venueAccess}</span> : null}
-                  {venuePhone ? <span>📞 {venuePhone}</span> : null}
+                  {venueMetro ? <span className="inline-flex items-center gap-1.5"><IconMetro size={14} /> {venueMetro}</span> : null}
+                  {venueAccess ? <span className="inline-flex items-center gap-1.5"><IconAccess size={14} /> {venueAccess}</span> : null}
+                  {venuePhone ? <span className="inline-flex items-center gap-1.5"><IconPhone size={14} /> {venuePhone}</span> : null}
                 </div>
               ) : null}
 
               {/* Amis qui aiment aussi */}
               {friends.length > 0 ? (
-                <p className="text-sm text-[color:var(--color-text)]">
-                  <span aria-hidden>👥 </span>
+                <p className="inline-flex items-center gap-1.5 text-sm text-[color:var(--color-text)]">
+                  <IconUsers size={15} />
                   <span className="text-muted-foreground">Aimé aussi par </span>
                   <span className="font-medium">{friends.map((f) => f.email.split('@')[0]).join(', ')}</span>
                 </p>
@@ -121,9 +122,9 @@ export default function LikeDetailModal({ work, fallbackTitle, friends, bucket, 
                   href={mapsUrl(work)}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="block text-center text-xs font-medium text-[color:var(--color-text-muted)] underline-offset-4 hover:text-[color:var(--color-accent)] hover:underline"
+                  className="inline-flex w-full items-center justify-center gap-1.5 text-xs font-medium text-[color:var(--color-text-muted)] underline-offset-4 hover:text-[color:var(--color-accent)] hover:underline"
                 >
-                  📍 Itinéraire
+                  <IconPin size={14} /> Itinéraire
                 </a>
               ) : null}
 

--- a/app/src/features/reactions/ui/LikesLibrary.tsx
+++ b/app/src/features/reactions/ui/LikesLibrary.tsx
@@ -235,7 +235,7 @@ export default function LikesLibrary({ current, archived, seen, friendsByWork, v
           />
 
           {items.length === 0 ? (
-            <div className="empty-state rounded-[var(--radius-lg)] border border-dashed border-[color:var(--color-border)] bg-white/50">
+            <div className="empty-state rounded-[var(--radius-lg)] border border-dashed border-[color:var(--color-border)] bg-white/5">
               <strong>Rien ne correspond à ce filtre.</strong>
             </div>
           ) : (
@@ -327,7 +327,7 @@ function Toolbar({
             </option>
           ))}
         </select>
-        <label className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[color:var(--color-border)] bg-white/70 px-3 py-1.5 text-xs font-medium">
+        <label className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[color:var(--color-border)] bg-white/5 px-3 py-1.5 text-xs font-medium">
           <input type="checkbox" checked={bookableOnly} onChange={(e) => onBookable(e.target.checked)} />
           Réservable
         </label>

--- a/app/src/features/works/ui/CardWork.tsx
+++ b/app/src/features/works/ui/CardWork.tsx
@@ -4,12 +4,15 @@ import SourceLink from '@/features/works/ui/SourceLink'
 import type { WorkCardDto } from '@/features/works/dto'
 import ExpandableDescription from '@/features/works/ui/ExpandableDescription'
 import { formatAvailability, formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
+import { IconAccess, IconClock, IconFilm, IconMetro, IconStar, IconTicket, IconTv } from '@/shared/ui/icons'
 
 const AVAILABILITY_CHIP_CLASS: Record<'success' | 'danger' | 'warning', string> = {
   success: 'bg-[color:var(--color-success-soft)] text-[color:var(--color-success)]',
-  warning: 'bg-[rgba(160,74,65,0.10)] text-[color:var(--color-danger)]',
+  warning: 'bg-[rgba(255,107,107,0.16)] text-[color:var(--color-danger)]',
   danger: 'bg-[color:var(--color-danger-soft)] text-[color:var(--color-danger)]',
 }
+
+const FACT_CHIP = 'inline-flex items-center gap-1.5 rounded-[var(--radius-control)] bg-white/[0.07] px-2.5 py-1 text-xs font-medium text-[color:var(--color-text)]'
 
 export default function CardWork({ work, counter }: { work: WorkCardDto; counter?: string }) {
   const durationLabel = formatDuration(work.durationMin)
@@ -23,25 +26,19 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
     work.rating != null && work.rating > 0 && (work.ratingCount ?? 0) >= 20
       ? work.rating.toFixed(1).replace('.', ',')
       : null
-  const hasFacts = Boolean(durationLabel) || Boolean(priceLabel) || Boolean(availability) || Boolean(ratingLabel)
-  // Ligne d'eyebrow : lieu + arrondissement (toutes sections « lieu » sauf le cinéma,
-  // qui affiche plutôt nationalité·année).
-  const venueLine = [work.venue, work.section !== 'cinema' ? work.arrondissement : null]
-    .filter(Boolean)
-    .join(' · ')
+  const hasFacts = Boolean(durationLabel) || Boolean(priceLabel) || Boolean(availability)
+  // Sous-titre sur l'affiche : nationalité·année (ciné) sinon lieu + arrondissement.
+  const venueLine = [work.venue, work.section !== 'cinema' ? work.arrondissement : null].filter(Boolean).join(' · ')
   const cinemaMeta = work.section === 'cinema' ? [work.country, work.year].filter(Boolean).join(' · ') : ''
-  // Cinéma : « N salles — quelques noms » (un film passe dans plusieurs cinémas).
   const cinemaVenuesLine =
     work.section === 'cinema' && work.cinemaVenueCount
       ? `${work.cinemaVenueCount} salle${work.cinemaVenueCount > 1 ? 's' : ''}${
           work.cinemaVenues.length ? ' · ' + work.cinemaVenues.slice(0, 2).join(', ') : ''
         }`
       : ''
-  // Infos pratiques du lieu (théâtre relié) : métro + accès.
   const venueMetro = work.venueInfo?.metro?.trim()
   const venueAccess = work.venueInfo?.access?.trim()
-  // Sources : lien dédié de la fiche (porté par le titre) > site du lieu (porté par
-  // le nom du lieu). Le bouton copier accompagne la source primaire disponible.
+  // Sources : lien dédié de la fiche (sur le titre) > site du lieu (sur le lieu).
   const officialUrl = work.officialUrl
   const venueWebsite = work.venueInfo?.website ?? null
 
@@ -51,7 +48,8 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
       tabIndex={-1}
       aria-describedby={`work-${work.id}-title`}
     >
-      <div className="relative min-h-[14rem] flex-1 overflow-hidden rounded-[var(--radius-xl)] bg-muted">
+      {/* Affiche dominante + surimpression (titre, note, section). */}
+      <div className="relative min-h-[20rem] flex-1 overflow-hidden">
         <WorkImage
           src={work.imageUrl}
           alt={work.title}
@@ -59,49 +57,48 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
           className="object-cover"
           priority
           fallback={
-            <div className="flex h-full items-center justify-center bg-[radial-gradient(circle_at_top,#fff3,transparent_55%)] text-sm text-muted-foreground">
+            <div className="flex h-full items-center justify-center bg-[radial-gradient(circle_at_top,#ffffff14,transparent_55%)] text-sm text-[color:var(--color-text-muted)]">
               Aucune image
             </div>
           }
         />
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/90 via-black/35 to-transparent" />
 
-        <span className="absolute right-3 top-3 rounded-full border border-white/35 bg-black/35 px-3 py-1 text-xs font-semibold uppercase tracking-[0.1em] text-white backdrop-blur-sm">
-          {sectionLabel}
-        </span>
         {counter ? (
-          <span className="absolute left-3 top-3 rounded-full border border-white/35 bg-black/35 px-3 py-1 text-xs font-medium tabular-nums text-white backdrop-blur-sm">
+          <span className="absolute left-3 top-3 rounded-full bg-black/55 px-2.5 py-1 text-xs font-medium tabular-nums text-white/90 backdrop-blur-sm">
             {counter}
           </span>
         ) : null}
-      </div>
+        <span className="absolute right-3 top-3 rounded-full bg-black/55 px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-white/90 backdrop-blur-sm">
+          {sectionLabel}
+        </span>
 
-      <div className="flex flex-col gap-2 p-4">
-        <div className="space-y-1">
-          {venueLine ? (
-            <SourceLink
-              label={venueLine}
-              href={venueWebsite}
-              copy={!officialUrl}
-              textClassName="text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]"
-            />
-          ) : null}
-          {cinemaMeta ? (
-            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
-              {cinemaMeta}
-            </p>
+        <div className="absolute inset-x-0 bottom-0 flex flex-col gap-1.5 p-4">
+          {ratingLabel ? (
+            <span className="inline-flex w-fit items-center gap-1 rounded-full bg-black/45 px-2.5 py-1 text-xs font-semibold text-[#f5c518] backdrop-blur-sm">
+              <IconStar size={13} /> {ratingLabel}
+            </span>
           ) : null}
           <h2
             id={`work-${work.id}-title`}
-            className="text-[1.4rem] font-semibold leading-[1.05] tracking-[-0.04em] text-[color:var(--color-text)]"
+            className="text-[1.55rem] font-semibold leading-[1.04] tracking-[-0.03em] text-white [text-shadow:0_1px_12px_rgba(0,0,0,0.5)]"
           >
             {officialUrl ? (
-              <SourceLink label={work.title} href={officialUrl} textClassName="text-[color:var(--color-text)]" />
+              <SourceLink label={work.title} href={officialUrl} textClassName="text-white" />
             ) : (
               work.title
             )}
           </h2>
+          {cinemaMeta ? (
+            <p className="text-sm font-medium text-white/75">{cinemaMeta}</p>
+          ) : venueLine ? (
+            <SourceLink label={venueLine} href={venueWebsite} copy={!officialUrl} textClassName="text-sm font-medium text-white/75" />
+          ) : null}
         </div>
+      </div>
 
+      {/* Bandeau d'infos sous l'affiche. */}
+      <div className="flex flex-col gap-2.5 p-4">
         {work.director || work.cast.length > 0 ? (
           <div className="space-y-0.5 text-sm leading-6">
             {work.director ? (
@@ -120,26 +117,33 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
         ) : null}
 
         {venueMetro || venueAccess ? (
-          <p className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[color:var(--color-text-muted)]">
-            {venueMetro ? <span>🚇 {venueMetro}</span> : null}
-            {venueAccess ? <span>♿ {venueAccess}</span> : null}
+          <p className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[color:var(--color-text-muted)]">
+            {venueMetro ? (
+              <span className="inline-flex items-center gap-1.5">
+                <IconMetro size={14} /> {venueMetro}
+              </span>
+            ) : null}
+            {venueAccess ? (
+              <span className="inline-flex items-center gap-1.5">
+                <IconAccess size={14} /> {venueAccess}
+              </span>
+            ) : null}
           </p>
         ) : null}
 
         {cinemaVenuesLine ? (
-          <p className="text-xs text-[color:var(--color-text-muted)]">🎬 {cinemaVenuesLine}</p>
+          <p className="inline-flex items-center gap-1.5 text-xs text-[color:var(--color-text-muted)]">
+            <IconFilm size={14} /> {cinemaVenuesLine}
+          </p>
         ) : null}
 
         {work.platforms && work.platforms.length > 0 ? (
           <div className="flex flex-wrap items-center gap-1.5">
-            <span className="text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
-              📺 Dispo sur
+            <span className="inline-flex items-center gap-1.5 text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
+              <IconTv size={14} /> Dispo sur
             </span>
             {work.platforms.map((p) => (
-              <span
-                key={p}
-                className="rounded-full bg-[rgba(54,39,24,0.06)] px-2.5 py-0.5 text-xs font-medium text-[color:var(--color-text)]"
-              >
+              <span key={p} className="rounded-full bg-white/[0.07] px-2.5 py-0.5 text-xs font-medium text-[color:var(--color-text)]">
                 {p}
               </span>
             ))}
@@ -148,23 +152,18 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
 
         {hasFacts ? (
           <div className="flex flex-wrap items-center gap-2">
-            {ratingLabel ? (
-              <span className="rounded-full bg-[rgba(212,160,23,0.16)] px-3 py-1 text-xs font-semibold text-[#7a5c00]">
-                ⭐ {ratingLabel}
-              </span>
-            ) : null}
             {durationLabel ? (
-              <span className="rounded-full bg-[rgba(54,39,24,0.06)] px-3 py-1 text-xs font-medium text-[color:var(--color-text)]">
-                ⏱️ {durationLabel}
+              <span className={FACT_CHIP}>
+                <IconClock size={13} /> {durationLabel}
               </span>
             ) : null}
             {priceLabel ? (
-              <span className="rounded-full bg-[rgba(54,39,24,0.06)] px-3 py-1 text-xs font-medium text-[color:var(--color-text)]">
-                💶 {priceLabel}
+              <span className={FACT_CHIP}>
+                <IconTicket size={13} /> {priceLabel}
               </span>
             ) : null}
             {availability ? (
-              <span className={`rounded-full px-3 py-1 text-xs font-semibold ${AVAILABILITY_CHIP_CLASS[availability.tone]}`}>
+              <span className={`rounded-[var(--radius-control)] px-2.5 py-1 text-xs font-semibold ${AVAILABILITY_CHIP_CLASS[availability.tone]}`}>
                 {availability.label}
               </span>
             ) : null}
@@ -172,12 +171,10 @@ export default function CardWork({ work, counter }: { work: WorkCardDto; counter
         ) : null}
 
         {/* key={work.id} : le deck réutilise l'instance de carte d'un swipe à l'autre ;
-            on remonte la description à chaque fiche pour repartir replié (« Voir plus »)
-            et ne pas conserver l'état déplié de la fiche précédente. */}
+            on remonte la description à chaque fiche pour repartir replié (« Voir plus »). */}
         {description ? <ExpandableDescription key={work.id} text={description} /> : null}
 
-        {/* Fallback Offi : seulement quand aucune source (lien dédié de la fiche ni site
-            du lieu) n'est disponible — ex. cinéma, ou lieu non encore relié. */}
+        {/* Fallback Offi : seulement quand aucune source (lien dédié ni site du lieu). */}
         {work.sourceUrl && !officialUrl && !venueWebsite ? (
           <a
             href={work.sourceUrl}

--- a/app/src/features/works/ui/SourceLink.tsx
+++ b/app/src/features/works/ui/SourceLink.tsx
@@ -58,7 +58,7 @@ export default function SourceLink({ label, href, textClassName, copy = true }: 
           onClick={onCopy}
           aria-label={copied ? 'Lien copié' : 'Copier le lien'}
           title={copied ? 'Copié !' : 'Copier le lien'}
-          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[color:var(--color-text-muted)] transition hover:bg-[rgba(54,39,24,0.08)] hover:text-[color:var(--color-accent)]"
+          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[color:var(--color-text-muted)] transition hover:bg-[rgba(255,255,255,0.08)] hover:text-[color:var(--color-accent)]"
         >
           {copied ? <CheckIcon /> : <CopyIcon />}
         </button>

--- a/app/src/features/works/ui/StreamingPlatformFilter.tsx
+++ b/app/src/features/works/ui/StreamingPlatformFilter.tsx
@@ -25,7 +25,7 @@ export default function StreamingPlatformFilter({ available, selected }: Props) 
         className={`rounded-full px-3 py-1 text-xs font-medium transition ${
           selectedSet.size === 0
             ? 'bg-[color:var(--color-accent)] text-white'
-            : 'bg-[rgba(54,39,24,0.06)] text-[color:var(--color-text)] hover:bg-[rgba(54,39,24,0.12)]'
+            : 'bg-[rgba(255,255,255,0.07)] text-[color:var(--color-text)] hover:bg-[rgba(255,255,255,0.14)]'
         }`}
       >
         Toutes
@@ -41,7 +41,7 @@ export default function StreamingPlatformFilter({ available, selected }: Props) 
             className={`rounded-full px-3 py-1 text-xs font-medium transition ${
               active
                 ? 'bg-[color:var(--color-accent)] text-white'
-                : 'bg-[rgba(54,39,24,0.06)] text-[color:var(--color-text)] hover:bg-[rgba(54,39,24,0.12)]'
+                : 'bg-[rgba(255,255,255,0.07)] text-[color:var(--color-text)] hover:bg-[rgba(255,255,255,0.14)]'
             }`}
           >
             {platform}

--- a/app/src/features/works/ui/SwipeDeck.tsx
+++ b/app/src/features/works/ui/SwipeDeck.tsx
@@ -308,7 +308,7 @@ export default function SwipeDeck({ items, totalCount }: Props) {
           <div
             key={item.id}
             aria-hidden
-            className="pointer-events-none absolute inset-x-[4%] top-6 bottom-16 rounded-[var(--radius-2xl)] border border-[color:var(--color-border)] bg-white/55 shadow-[0_22px_48px_rgba(54,39,24,0.10)]"
+            className="pointer-events-none absolute inset-x-[4%] top-6 bottom-16 rounded-[var(--radius-2xl)] border border-[color:var(--color-border)] bg-white/5 shadow-[0_22px_48px_rgba(255,255,255,0.10)]"
             style={{
               transform: `translateY(${(previewIndex + 1) * 14}px) scale(${1 - (previewIndex + 1) * 0.03})`,
               opacity: 0.9 - previewIndex * 0.18,
@@ -333,14 +333,14 @@ export default function SwipeDeck({ items, totalCount }: Props) {
           <div className="pointer-events-none absolute inset-x-6 top-6 flex items-start justify-between">
             <span
               aria-hidden
-              className="flex h-14 w-14 items-center justify-center rounded-full border-2 border-[color:var(--color-success)] bg-[rgba(232,244,237,0.92)] text-[color:var(--color-success)] opacity-0 shadow-[0_14px_30px_rgba(35,100,75,0.16)]"
+              className="flex h-14 w-14 items-center justify-center rounded-full border-2 border-[color:var(--color-success)] bg-[rgba(76,208,160,0.18)] text-[color:var(--color-success)] opacity-0 shadow-[0_14px_30px_rgba(0,0,0,0.45)]"
               style={{ opacity: Math.max(0, Math.min(1, dragX / 120)) }}
             >
               <IconHeart className="h-6 w-6" />
             </span>
             <span
               aria-hidden
-              className="flex h-14 w-14 items-center justify-center rounded-full border-2 border-[color:var(--color-danger)] bg-[rgba(249,236,233,0.94)] text-[color:var(--color-danger)] opacity-0 shadow-[0_14px_30px_rgba(160,74,65,0.14)]"
+              className="flex h-14 w-14 items-center justify-center rounded-full border-2 border-[color:var(--color-danger)] bg-[rgba(255,107,107,0.16)] text-[color:var(--color-danger)] opacity-0 shadow-[0_14px_30px_rgba(0,0,0,0.45)]"
               style={{ opacity: Math.max(0, Math.min(1, -dragX / 120)) }}
             >
               <IconX className="h-6 w-6" />

--- a/app/src/features/works/ui/WorkSummaryCard.tsx
+++ b/app/src/features/works/ui/WorkSummaryCard.tsx
@@ -4,6 +4,7 @@ import { workDirectorLabel, workSectionLabel } from '@/features/works/section'
 import BadgeCategory from '@/features/works/ui/BadgeCategory'
 import WorkImage from '@/features/works/ui/WorkImage'
 import SourceLink from '@/features/works/ui/SourceLink'
+import { IconTv } from '@/shared/ui/icons'
 import { formatDateRange, formatDuration, formatPriceRange } from '@/features/works/ui/work-formatters'
 import { cn } from '@/shared/lib/cn'
 import SurfaceCard from '@/shared/ui/SurfaceCard'
@@ -37,7 +38,7 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
   const venueWebsite = work?.venueInfo?.website ?? null
   const cinemaVenuesLine =
     work?.section === 'cinema' && work.cinemaVenueCount
-      ? `🎬 ${work.cinemaVenueCount} salle${work.cinemaVenueCount > 1 ? 's' : ''}${
+      ? `${work.cinemaVenueCount} salle${work.cinemaVenueCount > 1 ? 's' : ''}${
           work.cinemaVenues.length ? ' · ' + work.cinemaVenues.slice(0, 3).join(', ') : ''
         }`
       : ''
@@ -89,9 +90,11 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
           {cinemaVenuesLine ? <p className="text-sm text-muted-foreground">{cinemaVenuesLine}</p> : null}
           {work?.platforms && work.platforms.length > 0 ? (
             <div className="flex flex-wrap items-center gap-1.5">
-              <span className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">📺 Dispo sur</span>
+              <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                <IconTv size={14} /> Dispo sur
+              </span>
               {work.platforms.map((p) => (
-                <span key={p} className="rounded-full bg-[rgba(54,39,24,0.06)] px-2.5 py-0.5 text-xs font-medium text-[color:var(--color-text)]">
+                <span key={p} className="rounded-full bg-[rgba(255,255,255,0.07)] px-2.5 py-0.5 text-xs font-medium text-[color:var(--color-text)]">
                   {p}
                 </span>
               ))}
@@ -117,7 +120,7 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
         </div>
 
         <div className="grid gap-2 text-sm text-[color:var(--color-text)]">
-          {ratingLabel ? <SummaryRow label="Note" value={`⭐ ${ratingLabel}/10`} /> : null}
+          {ratingLabel ? <SummaryRow label="Note" value={`${ratingLabel} / 10`} /> : null}
           {dateLabel ? <SummaryRow label="Dates" value={dateLabel} /> : null}
           {priceLabel ? <SummaryRow label="Budget" value={priceLabel} /> : null}
           {durationLabel ? <SummaryRow label="Durée" value={durationLabel} /> : null}
@@ -147,7 +150,7 @@ export default function WorkSummaryCard({ work, fallbackTitle, actions, classNam
 
 function SummaryRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-start justify-between gap-3 rounded-[var(--radius-panel)] border border-[color:var(--color-border)] bg-white/60 px-3 py-2">
+    <div className="flex items-start justify-between gap-3 rounded-[var(--radius-panel)] border border-[color:var(--color-border)] bg-white/5 px-3 py-2">
       <span className="text-[0.72rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">{label}</span>
       <span className="text-right font-medium leading-6">{value}</span>
     </div>

--- a/app/src/shared/ui/icons.tsx
+++ b/app/src/shared/ui/icons.tsx
@@ -1,0 +1,116 @@
+// Jeu d'icônes maison (style « line », trait régulier). Remplace les emoji, qui
+// faisaient « template » et cassaient la cohérence visuelle. SVG inline → zéro
+// dépendance, couleur via currentColor, taille via la prop `size`.
+import type { SVGProps } from 'react'
+
+type IconProps = SVGProps<SVGSVGElement> & { size?: number }
+
+function Svg({ size = 16, children, ...props }: IconProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      {children}
+    </svg>
+  )
+}
+
+export function IconStar({ filled = true, size = 16, ...props }: IconProps & { filled?: boolean }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth={1.5} strokeLinejoin="round" aria-hidden {...props}>
+      <path d="M12 3.5l2.6 5.3 5.9.9-4.3 4.1 1 5.8-5.2-2.7-5.2 2.7 1-5.8L4.5 9.7l5.9-.9z" />
+    </svg>
+  )
+}
+
+export const IconClock = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="8.5" />
+    <path d="M12 7.5V12l3 1.8" />
+  </Svg>
+)
+
+export const IconTicket = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M3 8.5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2 2 2 0 0 0 0 7 2 2 0 0 1-2 2H5a2 2 0 0 1-2-2 2 2 0 0 0 0-7z" />
+    <path d="M14 6.5v11" strokeDasharray="2 2" />
+  </Svg>
+)
+
+export const IconPin = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 21s7-5.2 7-11a7 7 0 1 0-14 0c0 5.8 7 11 7 11z" />
+    <circle cx="12" cy="10" r="2.5" />
+  </Svg>
+)
+
+export const IconMetro = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="6" y="3.5" width="12" height="13" rx="3" />
+    <path d="M6 11h12M9.5 16.5l-2 3M14.5 16.5l2 3" />
+    <circle cx="9" cy="13.5" r="0.6" fill="currentColor" stroke="none" />
+    <circle cx="15" cy="13.5" r="0.6" fill="currentColor" stroke="none" />
+  </Svg>
+)
+
+export const IconAccess = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="12" cy="4.5" r="1.6" />
+    <path d="M9 8h5l-.5 4H15l2.5 6M9 8v4.5a3.5 3.5 0 0 0 3.5 3.5" />
+  </Svg>
+)
+
+export const IconFilm = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="3.5" y="4.5" width="17" height="15" rx="2" />
+    <path d="M3.5 9h17M3.5 15h17M8 4.5v15M16 4.5v15" />
+  </Svg>
+)
+
+export const IconTv = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="3" y="7" width="18" height="12" rx="2" />
+    <path d="M8 3.5l4 3.5 4-3.5" />
+  </Svg>
+)
+
+export const IconUsers = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="9" cy="8" r="3" />
+    <path d="M3.5 19a5.5 5.5 0 0 1 11 0M16 6.2a3 3 0 0 1 0 5.6M16.5 14.2A5.5 5.5 0 0 1 20.5 19" />
+  </Svg>
+)
+
+export const IconArrowUpRight = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M7 17 17 7M8 7h9v9" />
+  </Svg>
+)
+
+export const IconPhone = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M6.5 3.5h3l1.5 4-2 1.4a11 11 0 0 0 4.6 4.6l1.4-2 4 1.5v3a2 2 0 0 1-2.2 2A16.5 16.5 0 0 1 4.5 5.7 2 2 0 0 1 6.5 3.5z" />
+  </Svg>
+)
+
+export const IconCopy = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="9" y="9" width="11" height="11" rx="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </Svg>
+)
+
+export const IconCheck = (p: IconProps) => (
+  <Svg strokeWidth={2.2} {...p}>
+    <path d="M20 6 9 17l-5-5" />
+  </Svg>
+)

--- a/app/tests/card-work.test.tsx
+++ b/app/tests/card-work.test.tsx
@@ -92,12 +92,12 @@ describe('CardWork', () => {
     expect(screen.getByText('États-Unis · 2008')).toBeInTheDocument()
   })
 
-  it('affiche la note (⭐) quand elle a assez de votes, pas en dessous du seuil', () => {
+  it('affiche la note quand elle a assez de votes, pas en dessous du seuil', () => {
     const { rerender } = render(<CardWork work={{ ...base, rating: 8.44, ratingCount: 320 }} />)
-    expect(screen.getByText(/⭐ 8,4/)).toBeInTheDocument()
+    expect(screen.getByText(/8,4/)).toBeInTheDocument()
     // sous le seuil de votes → pas de note (trop bruitée)
     rerender(<CardWork work={{ ...base, id: 'w-low', rating: 9.5, ratingCount: 3 }} />)
-    expect(screen.queryByText(/⭐/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/9,5/)).not.toBeInTheDocument()
   })
 
   it('affiche un badge « Billets dispo » quand availability=InStock', () => {


### PR DESCRIPTION
## Refonte visuelle — « Cinéma sombre » (étapes 1→3)

Objectif : sortir du rendu « template / vibe-coding » en assumant une direction artistique.

### Ce qui change
- **Palette sombre** via les tokens CSS : fond quasi-noir, texte clair, **accent corail `#F25C54`**. Comme le thème est tokenisé, toute l'app bascule d'un coup. Rayons resserrés (moins « bubble »).
- **Fin des emoji-icônes** : 📍🚇♿🎬📺⭐⏱️💶👥 → un **vrai jeu d'icônes SVG maison** (`src/shared/ui/icons.tsx`), trait régulier. C'était le tell n°1.
- **Carte Découverte repensée** : affiche **plein cadre**, **titre + note ⭐ + section en surimpression** sur dégradé, infos en bandeau dessous (MUBI/Letterboxd).
- Littéraux chauds (chips bruns, surfaces blanches) remappés en overlays clairs/corail sur fond sombre dans tous les composants.

### À toi de juger 👀
Regarde la **preview Vercel** (lien dans le commentaire Vercel ci-dessous) — surtout **/discover** (les 7 onglets) et **/likes**. **Je ne merge pas tant que ça ne te plaît pas.**

### Reste à faire (étape 4, après ton retour)
Finitions pages **auth** (signin/signup) et **/friends**, contrastes, et tout ajustement que tu veux (intensité du corail, fond, typo des titres…).

Build ✓ · 120 tests ✓ · tsc ✓ · eslint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)