### PR TITLE
feat(auth): épurer connexion/inscription (retirer l'en-tête)

### DIFF
--- a/app/src/app/(auth)/signin/page.tsx
+++ b/app/src/app/(auth)/signin/page.tsx
@@ -41,14 +41,7 @@ function SignInInner() {
   return (
     <div className="flex h-full items-center">
       <SurfaceCard tone="accent" className="mx-auto w-full max-w-xl space-y-6 p-6 sm:p-8">
-        <div className="space-y-3">
-          <p className="page-eyebrow">Connexion</p>
-          <h1 className="page-title text-[clamp(1.9rem,4vw,2.7rem)]">Se connecter</h1>
-          <p className="page-description">
-            Retrouve ta pile de découvertes, tes likes et tes amis dans une interface plus calme et lisible.
-          </p>
-        </div>
-
+        <h1 className="sr-only">Se connecter</h1>
         <form onSubmit={onSubmit} className="space-y-5">
           <div className="space-y-2">
             <label className="label">Email</label>

--- a/app/src/app/(auth)/signup/page.tsx
+++ b/app/src/app/(auth)/signup/page.tsx
@@ -65,15 +65,7 @@ export default function SignUpPage() {
   return (
     <div className="flex h-full items-center">
       <SurfaceCard tone="accent" className="mx-auto w-full max-w-xl space-y-6 p-6 sm:p-8">
-        <div className="space-y-3">
-          <p className="page-eyebrow">Inscription</p>
-          <h1 className="page-title text-[clamp(1.9rem,4vw,2.7rem)]">Créer un compte</h1>
-          <p className="page-description">
-            Ouvre ton espace personnel pour construire une collection de sorties, partager des invitations et retrouver
-            plus vite les oeuvres qui comptent.
-          </p>
-        </div>
-
+        <h1 className="sr-only">Créer un compte</h1>
         <form onSubmit={onSubmit} className="space-y-5">
           <div className="space-y-2">
             <label className="label" htmlFor="signup-email">


### PR DESCRIPTION
Retire le bloc d'en-tête (« Connexion / Se connecter / Retrouve ta pile… » et l'équivalent inscription) sur les pages auth — le formulaire suffit. h1 conservé en `sr-only` pour l'accessibilité.

tsc ✓ · eslint ✓