### PR TITLE
fix(discover): deck à la largeur de la carte (corrige le fond desktop)

### DIFF
--- a/app/src/features/works/ui/SwipeDeck.tsx
+++ b/app/src/features/works/ui/SwipeDeck.tsx
@@ -339,7 +339,7 @@ export default function SwipeDeck({ items, totalCount }: Props) {
   return (
     <section
       aria-label="Sélection de découvertes à balayer"
-      className="mx-auto flex w-full max-w-5xl flex-col gap-3 select-none"
+      className="mx-auto flex w-full max-w-xl flex-col gap-3 select-none"
     >
       <div className="relative flex min-h-[30rem] items-center justify-center pb-2">
         {nextItems.map((item, previewIndex) => (

--- a/app/src/features/works/ui/SwipeDeck.tsx
+++ b/app/src/features/works/ui/SwipeDeck.tsx
@@ -86,7 +86,6 @@ export default function SwipeDeck({ items, totalCount }: Props) {
   const current = items[index]
   const hasMore = index < items.length
   const visibleTotal = totalCount ?? items.length
-  const nextItems = items.slice(index + 1, index + 3)
 
   const rotation = useMemo(() => dragX * 0.05, [dragX])
   const transform = useMemo(() => transformCss(dragX, rotation), [dragX, rotation])
@@ -342,18 +341,6 @@ export default function SwipeDeck({ items, totalCount }: Props) {
       className="mx-auto flex w-full max-w-xl flex-col gap-3 select-none"
     >
       <div className="relative flex min-h-[30rem] items-center justify-center pb-2">
-        {nextItems.map((item, previewIndex) => (
-          <div
-            key={item.id}
-            aria-hidden
-            className="pointer-events-none absolute inset-x-[4%] top-6 bottom-16 rounded-[var(--radius-2xl)] border border-[color:var(--color-border)] bg-[color:var(--color-surface)] shadow-[0_22px_48px_rgba(255,255,255,0.10)]"
-            style={{
-              transform: `translateY(${(previewIndex + 1) * 14}px) scale(${1 - (previewIndex + 1) * 0.03})`,
-              opacity: 0.9 - previewIndex * 0.18,
-            }}
-          />
-        ))}
-
         <div
           ref={cardRef}
           role="group"


### PR DESCRIPTION
Sur desktop, le « fond moche » = les cartes d'arrière-plan du deck Discover (`max-w-5xl`) débordaient largement de la carte (`max-w-xl`) dans le nouveau layout sidebar. On aligne le conteneur du deck sur la largeur de la carte (`max-w-xl`).

tsc ✓ · eslint ✓ · build ✓