### PR TITLE
fix(ux): croix retrait /likes + « Voir plus » + filtre streaming réactif

### DIFF
--- a/app/src/features/reactions/ui/CompactLikeCard.tsx
+++ b/app/src/features/reactions/ui/CompactLikeCard.tsx
@@ -16,11 +16,13 @@ type Props = {
   fallbackTitle: string
   friends: FriendSummaryDto[]
   onOpen: () => void
+  onRemove: () => void
 }
 
 // Carte compacte et cliquable (le détail s'ouvre dans une modale). Vignette à
 // gauche, titre + signaux d'action à droite (urgence, dispo, prix, amis).
-export default function CompactLikeCard({ work, fallbackTitle, friends, onOpen }: Props) {
+// Une croix en haut à droite retire directement l'œuvre des likes.
+export default function CompactLikeCard({ work, fallbackTitle, friends, onOpen, onRemove }: Props) {
   const title = work?.title ?? fallbackTitle
   const sectionLabel = workSectionLabel(work?.section)
   const ends = formatEndsIn(work?.endDate ?? null)
@@ -32,12 +34,23 @@ export default function CompactLikeCard({ work, fallbackTitle, friends, onOpen }
       : [work?.venue, work?.arrondissement].filter(Boolean).join(' · ')
 
   return (
-    <button
-      type="button"
-      onClick={onOpen}
-      className="group flex w-full items-stretch gap-3 overflow-hidden rounded-[var(--radius-lg)] border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] p-2 text-left transition hover:border-[color:var(--color-border-strong)] hover:shadow-[var(--shadow-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]"
-      aria-label={`Voir le détail de ${title}`}
-    >
+    <div className="group relative overflow-hidden rounded-[var(--radius-lg)] border border-[color:var(--color-border)] bg-[color:var(--color-surface-strong)] transition hover:border-[color:var(--color-border-strong)] hover:shadow-[var(--shadow-sm)]">
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Retirer « ${title} » des likes`}
+        className="absolute right-1.5 top-1.5 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full bg-[color:var(--color-surface)] text-[color:var(--color-text-muted)] backdrop-blur-sm transition hover:bg-[color:var(--color-danger-soft)] hover:text-[color:var(--color-danger)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-danger)]"
+      >
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" aria-hidden>
+          <path d="M6 6l12 12M18 6 6 18" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="flex w-full items-stretch gap-3 p-2 pr-9 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]"
+        aria-label={`Voir le détail de ${title}`}
+      >
       <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-[var(--radius-md)] bg-muted">
         <WorkImage
           src={work?.imageUrl}
@@ -93,6 +106,7 @@ export default function CompactLikeCard({ work, fallbackTitle, friends, onOpen }
           ) : null}
         </div>
       </div>
-    </button>
+      </button>
+    </div>
   )
 }

--- a/app/src/features/reactions/ui/LikesLibrary.tsx
+++ b/app/src/features/reactions/ui/LikesLibrary.tsx
@@ -253,6 +253,7 @@ export default function LikesLibrary({ current, archived, seen, friendsByWork, v
                     fallbackTitle={item.workId}
                     friends={friendsByWork[item.workId] ?? []}
                     onOpen={() => setSelected({ workId: item.workId, bucket: baseItems.bucket })}
+                    onRemove={() => remove(item, view === 'seen' ? 'seen' : bucketOf(item, active, archive))}
                   />
                 </li>
               ))}

--- a/app/src/features/works/ui/ExpandableDescription.tsx
+++ b/app/src/features/works/ui/ExpandableDescription.tsx
@@ -21,6 +21,9 @@ export default function ExpandableDescription({ text }: { text: string }) {
       {canExpand ? (
         <button
           type="button"
+          // stopPropagation : sinon la carte Découverte capture le pointeur (swipe)
+          // et « avale » le clic → le bouton ne basculait plus.
+          onPointerDown={(e) => e.stopPropagation()}
           onClick={() => setExpanded((value) => !value)}
           className="text-sm font-semibold text-[color:var(--color-accent)] underline-offset-4 hover:underline"
           aria-expanded={expanded}

--- a/app/src/features/works/ui/StreamingPlatformFilter.tsx
+++ b/app/src/features/works/ui/StreamingPlatformFilter.tsx
@@ -1,9 +1,13 @@
-import Link from 'next/link'
+'use client'
+
+import { useOptimistic, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { cn } from '@/shared/lib/cn'
 
 type Props = {
   /** Plateformes disponibles dans le catalogue. */
   available: string[]
-  /** Plateformes actuellement sélectionnées. */
+  /** Plateformes actuellement sélectionnées (depuis l'URL). */
   selected: string[]
 }
 
@@ -12,40 +16,44 @@ function hrefFor(platforms: string[]) {
   return platforms.length ? `${base}&platforms=${encodeURIComponent(platforms.join(','))}` : base
 }
 
-// Filtre plateformes de l'onglet Streaming : chaque puce ajoute/retire sa plateforme
-// du filtre (état porté par l'URL → re-rendu serveur du deck). « Toutes » réinitialise.
+// Filtre plateformes (onglet Streaming). État dans l'URL, mais la sélection est
+// **optimiste** : la puce s'active immédiatement (useOptimistic) pendant que le deck
+// se met à jour en arrière-plan → plus de latence perçue au clic.
 export default function StreamingPlatformFilter({ available, selected }: Props) {
+  const router = useRouter()
+  const [, startTransition] = useTransition()
+  const [optimistic, setOptimistic] = useOptimistic(selected)
+
   if (available.length === 0) return null
-  const selectedSet = new Set(selected)
+  const set = new Set(optimistic)
+
+  function go(next: string[]) {
+    startTransition(() => {
+      setOptimistic(next)
+      router.replace(hrefFor(next), { scroll: false })
+    })
+  }
+
+  const pill = (active: boolean) =>
+    cn(
+      'rounded-full px-3 py-1 text-xs font-medium transition',
+      active
+        ? 'bg-[color:var(--color-accent)] text-white'
+        : 'bg-[color:var(--color-fill)] text-[color:var(--color-text)] hover:bg-[color:var(--color-fill-hover)]',
+    )
 
   return (
     <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Filtrer par plateforme">
-      <Link
-        href={hrefFor([])}
-        className={`rounded-full px-3 py-1 text-xs font-medium transition ${
-          selectedSet.size === 0
-            ? 'bg-[color:var(--color-accent)] text-white'
-            : 'bg-[color:var(--color-fill)] text-[color:var(--color-text)] hover:bg-[color:var(--color-fill-hover)]'
-        }`}
-      >
+      <button type="button" onClick={() => go([])} className={pill(set.size === 0)}>
         Toutes
-      </Link>
+      </button>
       {available.map((platform) => {
-        const active = selectedSet.has(platform)
-        const next = active ? selected.filter((p) => p !== platform) : [...selected, platform]
+        const active = set.has(platform)
+        const next = active ? optimistic.filter((p) => p !== platform) : [...optimistic, platform]
         return (
-          <Link
-            key={platform}
-            href={hrefFor(next)}
-            aria-pressed={active}
-            className={`rounded-full px-3 py-1 text-xs font-medium transition ${
-              active
-                ? 'bg-[color:var(--color-accent)] text-white'
-                : 'bg-[color:var(--color-fill)] text-[color:var(--color-text)] hover:bg-[color:var(--color-fill-hover)]'
-            }`}
-          >
+          <button key={platform} type="button" aria-pressed={active} onClick={() => go(next)} className={pill(active)}>
             {platform}
-          </Link>
+          </button>
         )
       })}
     </div>


### PR DESCRIPTION
Trois correctifs UX :

1. **Croix de retrait** sur chaque carte de /likes (haut-droite) → retire l'œuvre directement (optimiste + toast d'annulation existant). `CompactLikeCard` restructurée (wrapper + bouton ouvrir + croix sœur, plus de bouton imbriqué).
2. **« Voir plus » réparé** : la carte Découverte capture le pointeur pour le swipe et « avalait » le clic du bouton → `stopPropagation` ajouté (comme les liens).
3. **Filtre plateformes streaming réactif** : passé en composant client avec `useOptimistic` → la puce s'active **instantanément** au clic, le deck se met à jour derrière (fini l'attente d'un aller-retour serveur complet à chaque clic).

tsc ✓ · eslint ✓ · 121 tests ✓ · build ✓

*Note : la lenteur de chargement initial de l'onglet streaming (3 277 films, requête + count) est un sujet distinct ; à creuser si besoin.*