### PR TITLE
perf(streaming): count via index GIN + cache des plateformes

### DIFF
--- a/app/src/app/discover/page.tsx
+++ b/app/src/app/discover/page.tsx
@@ -46,15 +46,22 @@ export default async function DiscoverPage({ searchParams }: DiscoverPageProps =
   // Le filtre plateformes ne s'applique que sur l'onglet streaming.
   const selectedPlatforms = isStreaming ? resolvePlatforms(resolvedSearchParams?.platforms) : []
 
-  const [works, availablePlatforms] = await Promise.all([
-    listDiscoverWorks({
-      userId: sessionUser?.id ?? null,
-      per: 200,
-      section,
-      platforms: selectedPlatforms.length ? selectedPlatforms : undefined,
-    }),
-    isStreaming ? listStreamingPlatforms() : Promise.resolve([]),
-  ])
+  // Liste des plateformes (mise en cache) AVANT la requête works : pour le streaming
+  // non filtré, on requête « hasSome: toutes les plateformes » (≡ dispo, mais via
+  // l'index GIN) plutôt que « isEmpty:false » (scan séquentiel, lent sur gros volume).
+  const availablePlatforms = isStreaming ? await listStreamingPlatforms() : []
+  const platformsForQuery = selectedPlatforms.length
+    ? selectedPlatforms
+    : isStreaming && availablePlatforms.length
+      ? availablePlatforms
+      : undefined
+
+  const works = await listDiscoverWorks({
+    userId: sessionUser?.id ?? null,
+    per: 200,
+    section,
+    platforms: platformsForQuery,
+  })
 
   return (
     <div className="page-shell">

--- a/app/src/features/works/server/queries.ts
+++ b/app/src/features/works/server/queries.ts
@@ -1,5 +1,6 @@
 import 'server-only'
 
+import { unstable_cache } from 'next/cache'
 import type { Prisma } from '@/generated/prisma/client'
 import { prisma } from '@/server/db'
 import { getParisTodayStart } from '@/features/works/availability'
@@ -57,11 +58,17 @@ export async function listDiscoverWorks(input: ListDiscoverWorksInput = {}) {
 }
 
 // Plateformes de streaming présentes dans le catalogue (options du filtre Découverte).
-export async function listStreamingPlatforms(): Promise<string[]> {
-  const rows = await prisma.$queryRaw<{ p: string }[]>`
-    SELECT DISTINCT unnest(platforms) AS p
-    FROM "Work"
-    WHERE section = 'streaming'
-    ORDER BY p`
-  return rows.map((r) => r.p)
-}
+// Mis en cache (revalidation 1 h) : le catalogue ne change qu'au refresh hebdo →
+// inutile de relancer ce DISTINCT à chaque chargement / clic de filtre.
+export const listStreamingPlatforms = unstable_cache(
+  async (): Promise<string[]> => {
+    const rows = await prisma.$queryRaw<{ p: string }[]>`
+      SELECT DISTINCT unnest(platforms) AS p
+      FROM "Work"
+      WHERE section = 'streaming'
+      ORDER BY p`
+    return rows.map((r) => r.p)
+  },
+  ['streaming-platforms'],
+  { revalidate: 3600 },
+)


### PR DESCRIPTION
Optimisation du chargement de l'onglet **Streaming**.

### Diagnostic (mesuré sur Neon)
- `count` avec `platforms isEmpty:false` = **non indexable** → scan séquentiel (~130 ms chaud, **plusieurs secondes à froid**). C'était le point lent.
- `findMany` (GIN) ~40–160 ms, `listStreamingPlatforms` (DISTINCT) ~450 ms à chaque chargement.

### Fix
1. Streaming non filtré : on requête `hasSome:[toutes les plateformes]` (≡ « a au moins une plateforme » = dispo, mais via l'**index GIN**) au lieu de `isEmpty:false`. → `count` **17–32 ms**.
2. `listStreamingPlatforms` **mis en cache** (`unstable_cache`, revalidate 1 h) — le catalogue ne bouge qu'au refresh hebdo. Plus de DISTINCT à chaque clic de filtre.

Résultat : ~600 ms → ~60 ms de requêtes par chargement streaming (hors cold-start Neon ~1 s, qui est une limite infra).

tsc ✓ · eslint ✓ · 121 tests ✓ · build ✓