### PR TITLE
fix(venues): métro par event plus propre (parseur + nettoyage)

### DIFF
--- a/app/scripts/clean-venue-metro.ts
+++ b/app/scripts/clean-venue-metro.ts
@@ -1,0 +1,79 @@
+// Nettoie Venue.metro (et access) là où le parsing a happé du texte parasite
+// (dates, noms de lieux concaténés…). On re-fetch UNIQUEMENT les lieux au métro
+// suspect, et on ré-extrait avec le parseur amélioré (scraper/parsers._clean_metro) :
+// les stations récupérables sont corrigées (« Charonne le 8… » → « Charonne »),
+// le bruit irrécupérable est mis à null.
+//
+// Usage : pnpm exec tsx --env-file=.env --env-file=.env.local scripts/clean-venue-metro.ts
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { prisma } from '@/server/db'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const scraperDir = path.resolve(here, '../../scraper')
+const PY = path.join(scraperDir, '.venv/bin/python')
+const CLI = path.join(scraperDir, 'extract_venue_cli.py')
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+
+// Métro suspect : contient un chiffre, un mot « lieu », ou trop long.
+const SUSPECT = /\d|th[ée][âa]tre|mus[ée]e|salle|cin[ée]ma|\bparis\b|spectacle|com[ée]die/i
+const isSuspect = (m: string | null) => !!m && (SUSPECT.test(m) || m.length > 32)
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function fetchHtml(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(15_000) })
+    return res.ok ? await res.text() : null
+  } catch {
+    return null
+  }
+}
+
+function extract(html: string, url: string, kind: string): { metro: string | null; access: string | null } | null {
+  const res = spawnSync(PY, [CLI, url, kind], {
+    input: html,
+    encoding: 'utf-8',
+    cwd: scraperDir,
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 10_000,
+    killSignal: 'SIGKILL',
+  })
+  if (res.status !== 0 || !res.stdout) return null
+  try {
+    const v = JSON.parse(res.stdout)
+    return { metro: v?.metro ?? null, access: v?.access ?? null }
+  } catch {
+    return null
+  }
+}
+
+async function main() {
+  const all = await prisma.venue.findMany({
+    where: { metro: { not: null } },
+    select: { id: true, kind: true, metro: true, sourceUrl: true },
+  })
+  const suspects = all.filter((v) => isSuspect(v.metro))
+  console.log(`${suspects.length} lieu(x) au métro suspect (sur ${all.length} avec métro)`)
+
+  let fixed = 0
+  let nulled = 0
+  for (const v of suspects) {
+    const html = await fetchHtml(v.sourceUrl)
+    const re = html ? extract(html, v.sourceUrl, v.kind) : null
+    const newMetro = re?.metro ?? null // parseur amélioré : station propre ou null
+    await prisma.venue.update({ where: { id: v.id }, data: { metro: newMetro, ...(re?.access ? { access: re.access } : {}) } })
+    if (newMetro) fixed += 1
+    else nulled += 1
+    await sleep(300)
+  }
+  console.log(JSON.stringify({ suspects: suspects.length, recoveredClean: fixed, nulled }))
+}
+
+main()
+  .catch((error) => {
+    console.error('[clean-venue-metro]', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/scraper/parsers.py
+++ b/scraper/parsers.py
@@ -287,6 +287,24 @@ def extract_offers(soup) -> dict:
 _OFFI_ID_RE = re.compile(r"-(\d+)(?:\.html)?(?:[?#].*)?$")
 _PHONE_RE = re.compile(r"\+?\d[\d .]{7,}\d")
 _METRO_RE = re.compile(r"M[ée]tro\s*:?\s*([A-Za-zÀ-ÿ0-9 '’\-]{3,60})", re.IGNORECASE)
+# Mots qui trahissent un texte happé par erreur (pas un nom de station).
+_METRO_JUNK_RE = re.compile(r"th[ée][âa]tre|mus[ée]e|salle|cin[ée]ma|\bparis\b|spectacle|com[ée]die", re.IGNORECASE)
+_METRO_TRAILING_RE = re.compile(r"\s+(?:le|la|les|en|au|aux|et|à|du|de|des|d'|l')\s*$", re.IGNORECASE)
+
+
+def _clean_metro(raw: str) -> Optional[str]:
+    """Nettoie le nom de station happé après « Métro : » (coupe rubrique suivante,
+    dates/chiffres, connecteur final orphelin) et rejette le bruit (noms de lieux)."""
+    if not raw:
+        return None
+    # Coupe à la rubrique suivante (Accès, Bus, RER…) puis au 1er chiffre (dates/années).
+    value = re.split(r"\s+(?:Acc[èe]s|Bus|Parking|Voiture|RER|Tram\w*|Horaires|T[ée]l)\b", raw)[0]
+    value = re.split(r"\d", value)[0]
+    value = _clean_credit(value)
+    value = _METRO_TRAILING_RE.sub("", value).strip()
+    if not value or len(value) > 32 or _METRO_JUNK_RE.search(value):
+        return None
+    return value or None
 
 
 def offi_id_from_url(url: Optional[str]) -> Optional[int]:
@@ -394,9 +412,7 @@ def extract_venue(soup, source_url: str, kind: str) -> Optional[dict]:
     metro = None
     mm = _METRO_RE.search(text)
     if mm:
-        # On coupe à la rubrique suivante (Accès, Bus, Parking, RER…).
-        metro = re.split(r"\s+(?:Acc[èe]s|Bus|Parking|Voiture|RER|Horaires|T[ée]l)\b", mm.group(1))[0]
-        metro = _clean_credit(metro) or None
+        metro = _clean_metro(mm.group(1))
     access = _venue_access_features(text)
 
     image = None

--- a/scraper/tests/test_parsers.py
+++ b/scraper/tests/test_parsers.py
@@ -229,6 +229,14 @@ class VenueTests(unittest.TestCase):
         self.assertTrue(v["image"].endswith("x.jpg"))
         self.assertEqual(v["website"], "http://www.lechaplin.fr")  # site officiel, pas le partage
 
+    def test_clean_metro(self):
+        # Coupe le texte parasite, garde les stations multi-mots, rejette le bruit.
+        self.assertEqual(parsers._clean_metro("Commerce Accès PMR"), "Commerce")
+        self.assertEqual(parsers._clean_metro("Charonne le 8 février 1962 en 2023"), "Charonne")
+        self.assertEqual(parsers._clean_metro("Notre-Dame des Champs"), "Notre-Dame des Champs")
+        self.assertEqual(parsers._clean_metro("Pont de Sèvres"), "Pont de Sèvres")
+        self.assertIsNone(parsers._clean_metro("pole Paris 2e Théâtre Mélo"))
+
     def test_extract_venue_requires_name(self):
         self.assertIsNone(parsers.extract_venue(_soup("<div>no h1</div>"), "https://www.offi.fr/cinema/x-1.html", "cinema"))
 


### PR DESCRIPTION
Le métro (info par event, tirée du lieu) était parfois sale (ex. *« Charonne le 8 février 1962 en 2023 »*, ou des noms de lieux concaténés).

- `parsers._clean_metro` : coupe le texte happé (rubrique suivante, dates/chiffres, connecteur final orphelin), garde les stations multi-mots (Pont de Sèvres, Notre-Dame des Champs), **rejette le bruit** (théâtre/musée/Paris Xe…).
- `clean-venue-metro.ts` : re-extraction des **19 lieux suspects** → 2 stations récupérées proprement, 17 mises à `null` (on n'affiche plus de charabia).

scraper 38 tests ✓.